### PR TITLE
Implementa Underpromotion

### DIFF
--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -370,13 +370,22 @@ void Gen::init_lookup_tables(){
 int calcularBonusHeuristicas(const int origem, const int destino){
     Gen::lance contraLance = Search::contraLance_heuristica[Game::lista_do_jogo[Game::hply].inicio][Game::lista_do_jogo[Game::hply].destino];
 
-    if (Search::killers_primarios[Game::ply].inicio == origem && Search::killers_primarios[Game::ply].destino == destino){
+    // Killer and counter-move tables store full lance values including the
+    // promote piece. For non-promotion moves both sides carry 0, so the
+    // equality stays consistent; for promotions it disambiguates variants.
+    if (Search::killers_primarios[Game::ply].inicio == origem
+        && Search::killers_primarios[Game::ply].destino == destino
+        && Search::killers_primarios[Game::ply].promove == Gen::lista_de_lances[mc].promove){
         return SCORE_KILLER_1;
     }
-    if (Search::killers_secundarios[Game::ply].inicio == origem && Search::killers_secundarios[Game::ply].destino == destino){
+    if (Search::killers_secundarios[Game::ply].inicio == origem
+        && Search::killers_secundarios[Game::ply].destino == destino
+        && Search::killers_secundarios[Game::ply].promove == Gen::lista_de_lances[mc].promove){
         return SCORE_KILLER_2;
     }
-    if (contraLance.inicio == origem && contraLance.destino == destino){
+    if (contraLance.inicio == origem
+        && contraLance.destino == destino
+        && contraLance.promove == Gen::lista_de_lances[mc].promove){
         return SCORE_CONTRALANCE;
     }
 
@@ -386,6 +395,7 @@ int calcularBonusHeuristicas(const int origem, const int destino){
 void adicionar_captura(const int origem, const int destino, const int score){
     Gen::lista_de_lances[mc].inicio = origem;
     Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = 0;
     Gen::lista_de_lances[mc].score = score; // ordena por capturas
     mc++;
 }
@@ -393,6 +403,7 @@ void adicionar_captura(const int origem, const int destino, const int score){
 void adicionar_roque(const int origem, const int destino){
     Gen::lista_de_lances[mc].inicio = origem;
     Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = 0;
     Gen::lista_de_lances[mc].score = SCORE_ROQUE; // ordena por roque TODO TESTAR SE ESSA ORDENAÇÃO REALMENTE RESULTA EM MELHORAS ????????
     mc++;
 }
@@ -400,7 +411,47 @@ void adicionar_roque(const int origem, const int destino){
 void adicionar_lance(const int origem, const int destino){
     Gen::lista_de_lances[mc].inicio = origem;
     Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = 0;
     Gen::lista_de_lances[mc].score = calcularBonusHeuristicas(origem, destino);
+    mc++;
+}
+
+// Emit the four promotion variants (Q, N, R, B) for a pawn reaching the back
+// rank. Captured-piece value is rolled into queen/knight scores so MVV/LVA is
+// preserved when the promotion is also a capture. Queen first → earlier
+// alpha-beta cutoffs in search. Under-promotion (R, B) gets a near-zero score
+// because it is almost never the best move; keeping it above history scores
+// for quiet moves risks poisoning the top of the list.
+void adicionar_promocao_variantes(const int origem, const int destino, const int piece_capturado){
+    const int cap_bonus = (piece_capturado < VAZIO) ? Values::pieces_valor[piece_capturado] : 0;
+    const bool is_capture = (piece_capturado < VAZIO);
+
+    // Queen
+    Gen::lista_de_lances[mc].inicio = origem;
+    Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = D;
+    Gen::lista_de_lances[mc].score = (is_capture ? SCORE_PROMO_Q_CAP : SCORE_PROMO_Q) + cap_bonus;
+    mc++;
+
+    // Knight
+    Gen::lista_de_lances[mc].inicio = origem;
+    Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = C;
+    Gen::lista_de_lances[mc].score = (is_capture ? SCORE_PROMO_N_CAP : SCORE_PROMO_N) + cap_bonus;
+    mc++;
+
+    // Rook
+    Gen::lista_de_lances[mc].inicio = origem;
+    Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = T;
+    Gen::lista_de_lances[mc].score = SCORE_PROMO_UNDER;
+    mc++;
+
+    // Bishop
+    Gen::lista_de_lances[mc].inicio = origem;
+    Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = B;
+    Gen::lista_de_lances[mc].score = SCORE_PROMO_UNDER;
     mc++;
 }
 
@@ -466,7 +517,12 @@ void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_esquerda[lado_a_mover][casa];
-        adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
+            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+        }
+        else{
+            adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        }
     }
 
     // 1.3 adiciona capturas de peao para a direita
@@ -474,18 +530,29 @@ void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
         casa = Bitboard::bitscan(t2);
         t2 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_direita[lado_a_mover][casa];
-        adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
+            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+        }
+        else{
+            adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        }
     }
-    
+
     // 1.4 adiciona avanços de peao
     while (t3){
         casa = Bitboard::bitscan(t3);
         t3 &= Bitboard::not_mask[casa];
-        adicionar_lance(casa, peao_uma_casa[lado_a_mover][casa]);
+        casa_destino = peao_uma_casa[lado_a_mover][casa];
+        if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
+            adicionar_promocao_variantes(casa, casa_destino, VAZIO);
+        }
+        else{
+            adicionar_lance(casa, casa_destino);
 
-        // 1.4.1 avanço duplo
-        if (Bitboard::fileiras[lado_a_mover][casa] == 1 && Bitboard::tabuleiro[peao_duas_casas[lado_a_mover][casa]] == VAZIO){
-            adicionar_lance(casa, peao_duas_casas[lado_a_mover][casa]);
+            // 1.4.1 avanço duplo (a double push can never reach the back rank)
+            if (Bitboard::fileiras[lado_a_mover][casa] == 1 && Bitboard::tabuleiro[peao_duas_casas[lado_a_mover][casa]] == VAZIO){
+                adicionar_lance(casa, peao_duas_casas[lado_a_mover][casa]);
+            }
         }
     }
 
@@ -629,7 +696,10 @@ void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){
     mc = Game::qntt_lances_totais[Game::ply];
 
 
-    // 1. gera capturas de peao
+    // 1. gera capturas de peao. Quiet pawn pushes to the back rank (quiet
+    // promotions) are deliberately NOT generated here: quiescence uses
+    // Update::fazer_captura which has no path for non-capture destinations,
+    // and expanding the qsearch move surface is a separate follow-up.
     // 1.1 verifica quais casas estao disponiveis
     if (lado_a_mover == BRANCAS){
         t1 = Bitboard::bit_pieces[BRANCAS][P] & ((Bitboard::bit_lados[PRETAS] & Bitboard::not_coluna_h) >> 7);
@@ -645,7 +715,12 @@ void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_esquerda[lado_a_mover][casa];
-        adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
+            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+        }
+        else{
+            adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        }
     }
 
     // 1.3 adiciona capturas de peao para a direita
@@ -653,7 +728,12 @@ void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){
         casa = Bitboard::bitscan(t2);
         t2 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_direita[lado_a_mover][casa];
-        adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
+            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+        }
+        else{
+            adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
+        }
     }
     
     // 2. gera capturas de cavalo
@@ -747,7 +827,7 @@ unsigned long long Gen::perft_node(int profunidade){
     gerar_lances(Game::lado, Game::xlado);
 
     for (int i = Game::qntt_lances_totais[Game::ply]; i < Game::qntt_lances_totais[Game::ply+1]; i++){
-        if (!Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino)){
+        if (!Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino, Gen::lista_de_lances[i].promove)){
             continue;
         }
         total += perft_node(profunidade - 1);
@@ -767,7 +847,7 @@ unsigned long long Gen::perft(int profunidade){
     gerar_lances(Game::lado, Game::xlado);
 
     for (int i = Game::qntt_lances_totais[Game::ply]; i < Game::qntt_lances_totais[Game::ply+1]; i++){
-        if (!Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino)){
+        if (!Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino, Gen::lista_de_lances[i].promove)){
             continue;
         }
 

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -416,12 +416,11 @@ void adicionar_lance(const int origem, const int destino){
     mc++;
 }
 
-// Emit the four promotion variants (Q, N, R, B) for a pawn reaching the back
-// rank. Captured-piece value is rolled into queen/knight scores so MVV/LVA is
-// preserved when the promotion is also a capture. Queen first → earlier
-// alpha-beta cutoffs in search. Under-promotion (R, B) gets a near-zero score
-// because it is almost never the best move; keeping it above history scores
-// for quiet moves risks poisoning the top of the list.
+// Emit Q + N promotion variants for a pawn reaching the back rank. Rook and
+// bishop are skipped: R-promotion only matters in rare stalemate-avoidance
+// positions, and B is dominated by Q in essentially every legal setup — the
+// branching-factor cost of generating them outweighs the Elo they save.
+// Captured-piece value is rolled into both scores so MVV/LVA is preserved.
 void adicionar_promocao_variantes(const int origem, const int destino, const int piece_capturado){
     const int cap_bonus = (piece_capturado < VAZIO) ? Values::pieces_valor[piece_capturado] : 0;
     const bool is_capture = (piece_capturado < VAZIO);
@@ -438,20 +437,6 @@ void adicionar_promocao_variantes(const int origem, const int destino, const int
     Gen::lista_de_lances[mc].destino = destino;
     Gen::lista_de_lances[mc].promove = C;
     Gen::lista_de_lances[mc].score = (is_capture ? SCORE_PROMO_N_CAP : SCORE_PROMO_N) + cap_bonus;
-    mc++;
-
-    // Rook
-    Gen::lista_de_lances[mc].inicio = origem;
-    Gen::lista_de_lances[mc].destino = destino;
-    Gen::lista_de_lances[mc].promove = T;
-    Gen::lista_de_lances[mc].score = SCORE_PROMO_UNDER;
-    mc++;
-
-    // Bishop
-    Gen::lista_de_lances[mc].inicio = origem;
-    Gen::lista_de_lances[mc].destino = destino;
-    Gen::lista_de_lances[mc].promove = B;
-    Gen::lista_de_lances[mc].score = SCORE_PROMO_UNDER;
     mc++;
 }
 

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -455,6 +455,18 @@ void adicionar_promocao_variantes(const int origem, const int destino, const int
     mc++;
 }
 
+// Queen-only capture-promotion for qsearch. Quiescence scores captures via
+// pesquisa_quiescence(inicio, destino) and makes them with Update::fazer_captura,
+// neither of which knows about the promote piece — so emitting N/R/B here just
+// forces SEE to run 4× with identical inputs and identical results. Emit Q only.
+void adicionar_promocao_captura_dama(const int origem, const int destino, const int piece_capturado){
+    Gen::lista_de_lances[mc].inicio = origem;
+    Gen::lista_de_lances[mc].destino = destino;
+    Gen::lista_de_lances[mc].promove = D;
+    Gen::lista_de_lances[mc].score = Values::px[piece_capturado];
+    mc++;
+}
+
 void gerar_en_passant(){
     int ep = Game::lista_do_jogo[Game::hply - 1].destino;
 
@@ -716,7 +728,7 @@ void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){
         t1 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_esquerda[lado_a_mover][casa];
         if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
-            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+            adicionar_promocao_captura_dama(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
         }
         else{
             adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
@@ -729,13 +741,13 @@ void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){
         t2 &= Bitboard::not_mask[casa];
         casa_destino = Gen::peao_direita[lado_a_mover][casa];
         if (Consts::linhas[casa_destino] == FILEIRA_1 || Consts::linhas[casa_destino] == FILEIRA_8){
-            adicionar_promocao_variantes(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
+            adicionar_promocao_captura_dama(casa, casa_destino, Bitboard::tabuleiro[casa_destino]);
         }
         else{
             adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
         }
     }
-    
+
     // 2. gera capturas de cavalo
     t1 = Bitboard::bit_pieces[lado_a_mover][C];
     while (t1){

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -16,7 +16,7 @@ Bitboard::u64 lock[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
 
 Bitboard::u64 Hash::chaveAtual, Hash::lockAtual;
 int Hash::hash_inicio, Hash::hash_destino;
-int Hash::hash_score, Hash::hash_depth, Hash::hash_bound;
+int Hash::hash_score, Hash::hash_depth, Hash::hash_bound, Hash::hash_promove;
 
 size_t Hash::tt_entries_per_side = 0;
 
@@ -120,7 +120,8 @@ void Hash::adicionar_chave(const int l, const int piece, const int casa){
 }
 
 void Hash::adicionar_hash(const int ld, const Gen::lance lc,
-                          const int score, const int depth, const int bound){
+                          const int score, const int depth, const int bound,
+                          const int promove){
     ensure_tt_allocated();
     hashp* ptr = &hashpos[ld][chaveAtual % tt_entries_per_side];
 
@@ -137,14 +138,22 @@ void Hash::adicionar_hash(const int ld, const Gen::lance lc,
     ptr->score    = (int32_t)  score_to_tt(score, Game::ply);
     ptr->depth    = (int8_t)   depth;
     ptr->bound    = (uint8_t)  bound;
+    ptr->promove  = (uint8_t)  promove;
 }
 
 void Hash::adicionar_pontuacao_de_hash(){
     for (int lance = Game::qntt_lances_totais[Game::ply]; lance < Game::qntt_lances_totais[Game::ply + 1]; lance++){
-        if (Gen::lista_de_lances[lance].inicio == hash_inicio && Gen::lista_de_lances[lance].destino == hash_destino){
-            Gen::lista_de_lances[lance].score = PONTUACAO_HASH;
-            return;
+        const Gen::lance &m = Gen::lista_de_lances[lance];
+        if (m.inicio != hash_inicio || m.destino != hash_destino){
+            continue;
         }
+        // With four promotion variants per (src,dst) pair, the promote piece
+        // disambiguates. For non-promotion entries both sides carry 0.
+        if (m.promove != hash_promove){
+            continue;
+        }
+        Gen::lista_de_lances[lance].score = PONTUACAO_HASH;
+        return;
     }
 }
 
@@ -198,6 +207,7 @@ bool Hash::hash_lookup(const int l){
     hash_score   = score_from_tt(e.score, Game::ply);
     hash_depth   = e.depth;
     hash_bound   = e.bound;
+    hash_promove = e.promove;
 
     return true;
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -20,12 +20,13 @@ namespace Hash{
         int32_t       score;
         int8_t        depth;
         uint8_t       bound;
-        uint8_t       _pad[2];
+        uint8_t       promove;
+        uint8_t       _pad;
     };
 
     extern Bitboard::u64 chaveAtual, lockAtual;
     extern int hash_inicio, hash_destino;
-    extern int hash_score, hash_depth, hash_bound;
+    extern int hash_score, hash_depth, hash_bound, hash_promove;
 
     // Number of TT entries per side. Set by iniciar_hash()/realocar_tt().
     extern size_t tt_entries_per_side;
@@ -35,7 +36,8 @@ namespace Hash{
     void limpar_tt();
     void realocar_tt(int size_mb);
     void adicionar_hash(const int ld, const Gen::lance lc,
-                        const int score, const int depth, const int bound);
+                        const int score, const int depth, const int bound,
+                        const int promove);
     void adicionar_chave(const int l, const int piece, const int casa);
 
     void adicionar_pontuacao_de_hash();

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -26,7 +26,7 @@ int tabuleiro_invertido = 0;
 int Interface::no_lances = 0;
 int Interface::lookup;
 
-extern int Interface::lance_inicio, Interface::lance_destino;
+extern int Interface::lance_inicio, Interface::lance_destino, Interface::lance_promove;
 
 int Interface::tempo_gasto;
 
@@ -58,8 +58,9 @@ int Interface::computar_tempo_para_lance(int remaining_ms, int inc_ms){
 }
 
 void Interface::obter_pv_uci(char *buf, int max_len, int profundidade){
-    Interface::lance_inicio = Hash::hash_inicio;
+    Interface::lance_inicio  = Hash::hash_inicio;
     Interface::lance_destino = Hash::hash_destino;
+    Interface::lance_promove = Hash::hash_promove;
 
     int pos = 0;
     buf[0] = '\0';
@@ -69,7 +70,7 @@ void Interface::obter_pv_uci(char *buf, int max_len, int profundidade){
             break;
         }
 
-        char *mv = Interface::lance_para_string(Hash::hash_inicio, Hash::hash_destino, 0);
+        char *mv = Interface::lance_para_string(Hash::hash_inicio, Hash::hash_destino, Hash::hash_promove);
         int len = strlen(mv);
         if (pos + len + 2 >= max_len){
             break;
@@ -81,7 +82,7 @@ void Interface::obter_pv_uci(char *buf, int max_len, int profundidade){
         pos += len;
         buf[pos] = '\0';
 
-        Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino);
+        Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino, Hash::hash_promove);
     }
 
     while (Game::ply){
@@ -92,8 +93,9 @@ void Interface::obter_pv_uci(char *buf, int max_len, int profundidade){
 int profundidade_perft;
 
 void Interface::exibir_melhor_linha(int profundidade){
-     Interface::lance_inicio = Hash::hash_inicio;
+     Interface::lance_inicio  = Hash::hash_inicio;
      Interface::lance_destino = Hash::hash_destino;
+     Interface::lance_promove = Hash::hash_promove;
 
      for (int x = 0; x < profundidade; x++){
         if (Hash::hash_lookup(Game::lado) == false){
@@ -102,7 +104,7 @@ void Interface::exibir_melhor_linha(int profundidade){
 
         printf(" ");
         print_lance_algebrico(Hash::hash_inicio, Hash::hash_destino);
-        Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino);
+        Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino, Hash::hash_promove);
      }
 
      while (Game::ply){
@@ -241,7 +243,7 @@ void Interface::print_resultado(){
     Gen::gerar_lances(Game::lado, Game::xlado);
 
     for (i = 0; i < Game::qntt_lances_totais[1]; ++i){
-        if (Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino)){
+        if (Update::fazer_lance(Gen::lista_de_lances[i].inicio, Gen::lista_de_lances[i].destino, Gen::lista_de_lances[i].promove)){
             Update::desfaz_lance();
             existem_lances_legais = true;
             break;
@@ -322,7 +324,7 @@ void Interface::lance_computador(bool verbose){
         }
     }
     
-    Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino);
+    Update::fazer_lance(Hash::hash_inicio, Hash::hash_destino, Hash::hash_promove);
 
     Eval::atualizar_materiais();
 
@@ -367,25 +369,32 @@ int Interface::converter_lance(char *lnc){
         ){
         return -1;
     }
-    
+
     inicio = lnc[0] - 'a';
     inicio += ((lnc[1] - '0') - 1) * 8;
     destino = lnc[2] - 'a';
     destino += ((lnc[3] - '0') - 1) * 8;
 
-    for (i = 0; i < Game::qntt_lances_totais[1]; i++){
-        if (Gen::lista_de_lances[i].inicio == inicio && Gen::lista_de_lances[i].destino == destino){
-            if (lnc[4] == 'n' || lnc[4]=='N'){
-                Gen::lista_de_lances[i].promove = C;
-            }
-            if (lnc[4] == 'b' || lnc[4]=='B'){
-                Gen::lista_de_lances[i].promove = B;
-            }
-            if (lnc[4] == 'r' || lnc[4]=='R'){
-                Gen::lista_de_lances[i].promove = T;
-            }
+    // Parse the optional promotion char. 0 = unspecified (UCI tolerance → queen).
+    int pp = 0;
+    if      (lnc[4] == 'q' || lnc[4] == 'Q') pp = D;
+    else if (lnc[4] == 'n' || lnc[4] == 'N') pp = C;
+    else if (lnc[4] == 'b' || lnc[4] == 'B') pp = B;
+    else if (lnc[4] == 'r' || lnc[4] == 'R') pp = T;
 
-            return i;
+    for (i = 0; i < Game::qntt_lances_totais[1]; i++){
+        const Gen::lance &m = Gen::lista_de_lances[i];
+        if (m.inicio != inicio || m.destino != destino){
+            continue;
+        }
+        if (m.promove == 0){
+            return i;                                 // non-promotion move
+        }
+        if (pp == 0 && m.promove == D){
+            return i;                                 // UCI tolerance: default queen
+        }
+        if (pp != 0 && m.promove == pp){
+            return i;                                 // explicit match
         }
     }
 
@@ -399,30 +408,15 @@ void processar_lance_do_usuario(char lnc[TAMANHO_MAXIMO_COMANDO]){
 
     lance_usuario = Interface::converter_lance(lnc);
 
-    if (lance_usuario == -1 || !Update::fazer_lance(Gen::lista_de_lances[lance_usuario].inicio, Gen::lista_de_lances[lance_usuario].destino)){
+    if (lance_usuario == -1
+        || !Update::fazer_lance(Gen::lista_de_lances[lance_usuario].inicio,
+                                Gen::lista_de_lances[lance_usuario].destino,
+                                Gen::lista_de_lances[lance_usuario].promove)){
         printf("Comando / Lance inválido\n");
         printf("Digite 'ajuda' para exibir uma lista de comandos válidos ou\n");
         printf("Digite 'lances' para exibir uma lista de lances legais\n");
         printf("\n");
         return;
-    }
-
-    // atualiza peça promovida
-    if (Gen::lista_de_lances[Game::hply - 1].promove > P && (Consts::colunas[Gen::lista_de_lances[lance_usuario].destino] == FILEIRA_1 || Consts::colunas[Gen::lista_de_lances[lance_usuario].destino] == FILEIRA_8)){
-        Update::remover_piece(Game::xlado, D, Gen::lista_de_lances[lance_usuario].destino);
-
-        if (lnc[PROMOCAO] == 'n' || lnc[PROMOCAO] == 'N'){
-            Update::adicionar_piece(Game::xlado, C, Gen::lista_de_lances[lance_usuario].destino);
-        }
-        else if (lnc[PROMOCAO] == 'b' || lnc[PROMOCAO] == 'B'){
-            Update::adicionar_piece(Game::xlado, B, Gen::lista_de_lances[lance_usuario].destino);
-        }
-        else if (lnc[PROMOCAO] == 'r' || lnc[PROMOCAO] == 'R'){
-            Update::adicionar_piece(Game::xlado, T, Gen::lista_de_lances[lance_usuario].destino);
-        }
-        else{
-            Update::adicionar_piece(Game::xlado, D, Gen::lista_de_lances[lance_usuario].destino);
-        }
     }
 
     return;

--- a/src/interface.h
+++ b/src/interface.h
@@ -38,7 +38,7 @@ namespace Interface{
 
     extern int tempo_gasto;
 
-    extern int lance_inicio, lance_destino;
+    extern int lance_inicio, lance_destino, lance_promove;
 
     extern int no_lances;
 

--- a/src/params.h
+++ b/src/params.h
@@ -18,7 +18,11 @@ namespace Params{
     #define MIN_TT_MB     1
     #define MAX_TT_MB     4096
 
-    #define PILHA_DE_LANCES 4000
+    // Shared move buffer sized for worst-case ply-stacking during deep search +
+    // quiescence. Four-variant promotion generation can spike a single ply's
+    // count well above 80, and ~80 effective plies × ~100 moves → ~8k; 10k
+    // leaves a comfortable safety margin.
+    #define PILHA_DE_LANCES 10000
     #define PILHA_DO_JOGO 2000
 
     #define MAGIC_HASHTABLE_SIZE 4096

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -24,7 +24,7 @@ Gen::lance Search::killers_secundarios[MAX_PLY];
 jmp_buf env;
 bool parar_pesquisa;
 
-int Interface::lance_inicio, Interface::lance_destino;
+int Interface::lance_inicio, Interface::lance_destino, Interface::lance_promove;
 
 void verificar_tempo(){
     if ((Interface::obter_tempo() >= Search::tempo_do_fim || (Interface::tempo_maximo < 50 && Game::ply > 1)) && Interface::profundidade_fixa == 0 && Game::ply > 1){
@@ -164,7 +164,8 @@ int pesquisa_rapida(int alpha, int beta){
         if (score_capturas >= beta){
             if (melhorscore > 0){
                 Hash::adicionar_hash(Game::lado, Gen::lista_de_lances[melhorlance],
-                                     score_capturas, 0, TT_BOUND_LOWER);
+                                     score_capturas, 0, TT_BOUND_LOWER,
+                                     Gen::lista_de_lances[melhorlance].promove);
             }
 
             return score_capturas;
@@ -245,7 +246,7 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
         ordenar_lances(candidato);
 
         // verifica se o lance é legal
-        if (!Update::fazer_lance(Gen::lista_de_lances[candidato].inicio, Gen::lista_de_lances[candidato].destino)){
+        if (!Update::fazer_lance(Gen::lista_de_lances[candidato].inicio, Gen::lista_de_lances[candidato].destino, Gen::lista_de_lances[candidato].promove)){
             continue;
         }
 
@@ -301,7 +302,8 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
                 }
 
                 Hash::adicionar_hash(Game::lado, Gen::lista_de_lances[candidato],
-                                     score_candidato, profundidade, TT_BOUND_LOWER);
+                                     score_candidato, profundidade, TT_BOUND_LOWER,
+                                     Gen::lista_de_lances[candidato].promove);
 
                 return beta;
             }
@@ -324,7 +326,7 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
     }
 
     const int tt_store_bound = (melhorscore > alpha_original) ? TT_BOUND_EXACT : TT_BOUND_UPPER;
-    Hash::adicionar_hash(Game::lado, melhorlance, melhorscore, profundidade, tt_store_bound);
+    Hash::adicionar_hash(Game::lado, melhorlance, melhorscore, profundidade, tt_store_bound, melhorlance.promove);
 
     return alpha;
 }
@@ -442,8 +444,9 @@ void Search::pensar(bool verbose){
             }
         }
         else{
-            Interface::lance_inicio = 0;
+            Interface::lance_inicio  = 0;
             Interface::lance_destino = 0;
+            Interface::lance_promove = 0;
         }
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,10 +27,10 @@ static void send_bestmove(){
         destino = Interface::lance_destino;
     }
 
-    int promove = 0;
-    if (Bitboard::tabuleiro[inicio] == P &&
+    int promove = Interface::lance_promove;
+    if (promove == 0 && Bitboard::tabuleiro[inicio] == P &&
         (Consts::linhas[destino] == 0 || Consts::linhas[destino] == 7)){
-        promove = D;
+        promove = D;   // safety fallback for moves that bypass the PV save path
     }
 
     printf("bestmove %s\n", Interface::lance_para_string(inicio, destino, promove));
@@ -52,7 +52,8 @@ static void apply_moves_from_tokens(char *tok){
         }
 
         if (!Update::fazer_lance(Gen::lista_de_lances[idx].inicio,
-                                 Gen::lista_de_lances[idx].destino)){
+                                 Gen::lista_de_lances[idx].destino,
+                                 Gen::lista_de_lances[idx].promove)){
             printf("info string illegal move in position command: %s\n", tok);
             fflush(stdout);
             return;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -62,8 +62,8 @@ void Update::desfaz_lance(){
         adicionar_piece(Game::xlado, P, destino + casa_reversa[Game::lado]);
     }
 
-    // desfaz promoção
-    if (ultimo_lance->promove == D){
+    // desfaz promoção (any of C, B, T, D)
+    if (ultimo_lance->promove >= C && ultimo_lance->promove <= D){
         adicionar_piece(Game::lado, P, inicio);
         remover_piece(Game::lado, Bitboard::tabuleiro[destino], destino);
     }
@@ -98,7 +98,7 @@ void Update::desfaz_lance(){
     }
 }
 
-bool Update::fazer_lance(const int inicio, const int destino){
+bool Update::fazer_lance(const int inicio, const int destino, const int promove){
     // 1. lida com o roque do rei, movendo também a torre
     if (abs(inicio - destino) == ROQUE && Bitboard::tabuleiro[inicio] == R){
 
@@ -173,8 +173,9 @@ bool Update::fazer_lance(const int inicio, const int destino){
                 remover_piece(Game::xlado, Bitboard::tabuleiro[destino], destino);
             }
 
-            adicionar_piece(Game::lado, D, destino);
-            j->promove = D;
+            const int promo_piece = (promove >= C && promove <= D) ? promove : D;
+            adicionar_piece(Game::lado, promo_piece, destino);
+            j->promove = promo_piece;
         }
         // capturas
         else if (Bitboard::tabuleiro[destino] < VAZIO){

--- a/src/update.h
+++ b/src/update.h
@@ -7,7 +7,7 @@ namespace Update{
     const int fileira_de_promocao[LADOS] = {FILEIRA_8, FILEIRA_1};
 
     void adicionar_piece(const int l, const int piece, const int casa);
-    bool fazer_lance(const int inicio, const int destino);
+    bool fazer_lance(const int inicio, const int destino, const int promove = 0);
     void remover_piece(const int l, const int p, const int casa);
     int fazer_captura(const int inicio, const int destino);
     void setar_posicao(char posicao[80], char lado_a_jogar[1], char roques[4], char casa_en_passant[2], char hm[4], char fm[4]);

--- a/src/values.h
+++ b/src/values.h
@@ -47,11 +47,12 @@ namespace Values{
 	#define SCORE_CAPTURAS_V  50000000
 	#define PONTUACAO_HASH   100000000
 
-	// Promotion move scoring. Queen above MVV/LVA so it is always tried first,
-	// knight moderate (tactical value), rook/bishop near zero because they are
-	// almost never best and we don't want them polluting the top of the list.
-	#define SCORE_PROMO_Q_CAP  (SCORE_CAPTURAS_V + 1000000)
-	#define SCORE_PROMO_Q      60000000
+	// Promotion move scoring. Capture-promotions rank above quiet promotions
+	// (more material gain). Both queen variants sit above MVV/LVA so they are
+	// always tried before regular captures. Knight moderate (tactical value),
+	// rook/bishop near zero because they are almost never best.
+	#define SCORE_PROMO_Q_CAP  60000000
+	#define SCORE_PROMO_Q      (SCORE_CAPTURAS_V + 1000000)
 	#define SCORE_PROMO_N_CAP  18000000
 	#define SCORE_PROMO_N      17000000
 	#define SCORE_PROMO_UNDER  100

--- a/src/values.h
+++ b/src/values.h
@@ -48,13 +48,11 @@ namespace Values{
 	#define PONTUACAO_HASH   100000000
 
 	// Promotion move scoring. Queen above MVV/LVA so it is always tried first,
-	// knight moderate (tactical value), rook/bishop near zero because they are
-	// almost never best and we don't want them polluting the top of the list.
+	// knight moderate (tactical value). R/B are not generated.
 	#define SCORE_PROMO_Q_CAP  (SCORE_CAPTURAS_V + 1000000)
 	#define SCORE_PROMO_Q      60000000
 	#define SCORE_PROMO_N_CAP  18000000
 	#define SCORE_PROMO_N      17000000
-	#define SCORE_PROMO_UNDER  100
 
 	#define REDUCAO_LMR 3
 

--- a/src/values.h
+++ b/src/values.h
@@ -47,6 +47,15 @@ namespace Values{
 	#define SCORE_CAPTURAS_V  50000000
 	#define PONTUACAO_HASH   100000000
 
+	// Promotion move scoring. Queen above MVV/LVA so it is always tried first,
+	// knight moderate (tactical value), rook/bishop near zero because they are
+	// almost never best and we don't want them polluting the top of the list.
+	#define SCORE_PROMO_Q_CAP  (SCORE_CAPTURAS_V + 1000000)
+	#define SCORE_PROMO_Q      60000000
+	#define SCORE_PROMO_N_CAP  18000000
+	#define SCORE_PROMO_N      17000000
+	#define SCORE_PROMO_UNDER  100
+
 	#define REDUCAO_LMR 3
 
 	// ordenação de capturas

--- a/src/values.h
+++ b/src/values.h
@@ -47,12 +47,11 @@ namespace Values{
 	#define SCORE_CAPTURAS_V  50000000
 	#define PONTUACAO_HASH   100000000
 
-	// Promotion move scoring. Capture-promotions rank above quiet promotions
-	// (more material gain). Both queen variants sit above MVV/LVA so they are
-	// always tried before regular captures. Knight moderate (tactical value),
-	// rook/bishop near zero because they are almost never best.
-	#define SCORE_PROMO_Q_CAP  60000000
-	#define SCORE_PROMO_Q      (SCORE_CAPTURAS_V + 1000000)
+	// Promotion move scoring. Queen above MVV/LVA so it is always tried first,
+	// knight moderate (tactical value), rook/bishop near zero because they are
+	// almost never best and we don't want them polluting the top of the list.
+	#define SCORE_PROMO_Q_CAP  (SCORE_CAPTURAS_V + 1000000)
+	#define SCORE_PROMO_Q      60000000
 	#define SCORE_PROMO_N_CAP  18000000
 	#define SCORE_PROMO_N      17000000
 	#define SCORE_PROMO_UNDER  100

--- a/src/xboard.cpp
+++ b/src/xboard.cpp
@@ -49,14 +49,15 @@ void Xboard::xboard(){
 
 			Gen::lista_de_lances[0].inicio = Hash::hash_inicio;
             Gen::lista_de_lances[0].destino = Hash::hash_destino;
-            
-			if ((Bitboard::tabuleiro[Hash::hash_inicio] == P) && (Consts::linhas[Hash::hash_destino] == Update::fileira_de_promocao[Game::lado])){
-				prom = D; // ASSUME QUE O JOGADOR IRÁ PROMOVER SEMPRE PARA DAMA
+
+			prom = Interface::lance_promove;
+			if (prom == 0 && (Bitboard::tabuleiro[Hash::hash_inicio] == P) && (Consts::linhas[Hash::hash_destino] == Update::fileira_de_promocao[Game::lado])){
+				prom = D;   // safety fallback
 			}
 
 			printf("move %s\n", Interface::lance_para_string(Hash::hash_inicio,Hash::hash_destino,prom));
-	
-			Update::fazer_lance(Hash::hash_inicio,Hash::hash_destino);
+
+			Update::fazer_lance(Hash::hash_inicio,Hash::hash_destino,Hash::hash_promove);
   
 			Game::ply = 0;
 			Gen::gerar_lances(Game::lado, Game::xlado);
@@ -233,7 +234,7 @@ void Xboard::xboard(){
 		Gen::gerar_lances(Game::lado, Game::xlado);
 
 		m = Interface::converter_lance(linha);
-		if (m == -1 || !Update::fazer_lance(Gen::lista_de_lances[m].inicio, Gen::lista_de_lances[m].destino)){
+		if (m == -1 || !Update::fazer_lance(Gen::lista_de_lances[m].inicio, Gen::lista_de_lances[m].destino, Gen::lista_de_lances[m].promove)){
 			printf("Error (unknown comand): %s\n", comando);
         }
 		else {

--- a/tests/sprt/run_sprt.sh
+++ b/tests/sprt/run_sprt.sh
@@ -13,12 +13,12 @@
 #   tc           10+0.1            (10 sec + 0.1 sec increment)
 #   elo0         0                 (null hypothesis lower bound)
 #   elo1         5                 (null hypothesis upper bound: gain 5 Elo)
-#   concurrency  (nproc) / 2       (leave some cores for the OS)
+#   concurrency  4                 (leaves CPU headroom for clean TC timing)
 #
 # Environment overrides:
 #   FASTCHESS    path to fastchess binary (default: fastchess on PATH)
 #   BOOK         path to opening book (default: UHO if present, else starter)
-#   HASH         TT hash MB per engine (default: 64)
+#   HASH         TT hash MB per engine (default: 256)
 #   ALPHA BETA   SPRT type-I / type-II error rates (default: 0.05 / 0.05)
 #   ROUNDS       max rounds cap (default: 40000)
 #
@@ -51,7 +51,7 @@ if [ -z "$BASELINE" ] || [ -z "$CANDIDATE" ]; then
     cat >&2 <<USAGE
 Usage: $0 <baseline_binary> <candidate_binary> [tc] [elo0] [elo1] [concurrency]
 
-Defaults: tc=10+0.1 elo0=0 elo1=5 concurrency=(nproc)/2
+Defaults: tc=10+0.1 elo0=0 elo1=5 concurrency=4
 Environment: FASTCHESS BOOK HASH ALPHA BETA ROUNDS
 USAGE
     exit 64
@@ -100,17 +100,10 @@ if [ ! -f "$BOOK" ]; then
 fi
 
 if [ -z "$CONCURRENCY" ]; then
-    if command -v nproc >/dev/null 2>&1; then
-        CONCURRENCY=$(( $(nproc) / 2 ))
-    elif command -v sysctl >/dev/null 2>&1; then
-        CONCURRENCY=$(( $(sysctl -n hw.ncpu) / 2 ))
-    else
-        CONCURRENCY=2
-    fi
-    [ "$CONCURRENCY" -lt 1 ] && CONCURRENCY=1
+    CONCURRENCY=4
 fi
 
-HASH="${HASH:-64}"
+HASH="${HASH:-256}"
 ALPHA="${ALPHA:-0.05}"
 BETA="${BETA:-0.05}"
 ROUNDS="${ROUNDS:-40000}"


### PR DESCRIPTION
- Promoções geradas: Dama (por default) + Cavalo (Analisado em última instância)
- Promoções de Bispo e Torre são redundantes e não são geradas. Diminui o branching factor da árvore de pesquisa em finais com o trade-off de não evitar stalemate corretamente em certas posições. A engine deverá usar a pesquisa para encontrar linhas que evitam empate.