### PR TITLE
representa lances com struct de 8 bytes

### DIFF
--- a/src/gen.h
+++ b/src/gen.h
@@ -1,15 +1,25 @@
 #ifndef GEN
 #define GEN
 
+#include <cstdint>
+
 #include "bitboard.h"
 #include "params.h"
 
 namespace Gen{
+    // Packed move: squares fit in 6 bits (0-63), promotion piece in 4 bits
+    // (0-15, actual range 0-5). Stored as uint8_t for direct byte load/store
+    // (no bit-field shift+mask overhead). Score stays int32_t — values reach
+    // ~1e8 for the TT move boost, well outside 16-bit range.
+    // Layout: 4 bytes payload + 4 bytes score = 8 bytes per entry
+    // (was 16 bytes as 4× int). Halves footprint of lista_de_lances,
+    // killers_primarios/secundarios, and contraLance_heuristica.
     typedef struct{
-        int inicio;
-        int destino;
-        int promove;
-        int score;
+        uint8_t inicio;
+        uint8_t destino;
+        uint8_t promove;
+        uint8_t _pad;
+        int32_t score;
     } lance;
 
     extern lance lista_de_lances[PILHA_DE_LANCES];


### PR DESCRIPTION
Esse PR reduz em 50% o tamanho do struct usado para representar lances apenas alterando a tipagem dos squares e flags