### PR TITLE
Staged move picker

### DIFF
--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -484,32 +484,25 @@ void gerar_roques(){
     }
 }
 
-void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
+void Gen::gerar_capturas_busca(const int lado_a_mover, const int contraLado){
     int casa, casa_destino;
-
-    Bitboard::u64 t1, t2, t3;
-
+    Bitboard::u64 t1, t2;
     Bitboard::u64 ataques_deslizantes;
 
     mc = Game::qntt_lances_totais[Game::ply];
 
     gerar_en_passant();
-    gerar_roques();
 
-    // 1. gera os lances de peao
-    // 1.1 verifica quais casas estao disponiveis
+    // 1. capturas de peao (promoção emite Q+N via adicionar_promocao_variantes)
     if (lado_a_mover == BRANCAS){
         t1 = Bitboard::bit_pieces[BRANCAS][P] & ((Bitboard::bit_lados[PRETAS] & Bitboard::not_coluna_h) >> 7);
         t2 = Bitboard::bit_pieces[BRANCAS][P] & ((Bitboard::bit_lados[PRETAS] & Bitboard::not_coluna_a) >> 9);
-        t3 = Bitboard::bit_pieces[BRANCAS][P] & ~(Bitboard::bit_total>>8);
     }
     else{
         t1 = Bitboard::bit_pieces[PRETAS][P] & ((Bitboard::bit_lados[BRANCAS] & Bitboard::not_coluna_h) << 9);
         t2 = Bitboard::bit_pieces[PRETAS][P] & ((Bitboard::bit_lados[BRANCAS] & Bitboard::not_coluna_a) << 7);
-        t3 = Bitboard::bit_pieces[PRETAS][P] & ~(Bitboard::bit_total<<8);
     }
 
-    // 1.2 adiciona capturas de peao para a esquerda
     while (t1){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
@@ -521,8 +514,6 @@ void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
             adicionar_captura(casa, casa_destino, Values::px[Bitboard::tabuleiro[casa_destino]]);
         }
     }
-
-    // 1.3 adiciona capturas de peao para a direita
     while (t2){
         casa = Bitboard::bitscan(t2);
         t2 &= Bitboard::not_mask[casa];
@@ -535,7 +526,99 @@ void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
         }
     }
 
-    // 1.4 adiciona avanços de peao
+    // 2. capturas de cavalo
+    t1 = Bitboard::bit_pieces[lado_a_mover][C];
+    while (t1){
+        casa = Bitboard::bitscan(t1);
+        t1 &= Bitboard::not_mask[casa];
+        t2 = Gen::bit_moves_cavalo[casa] & Bitboard::bit_lados[contraLado];
+        while (t2){
+            casa_destino = Bitboard::bitscan(t2);
+            t2 &= Bitboard::not_mask[casa_destino];
+            adicionar_captura(casa, casa_destino, Values::cx[Bitboard::tabuleiro[casa_destino]]);
+        }
+    }
+
+    // 3. capturas de bispo (magics → apenas alvos inimigos)
+    t1 = Bitboard::bit_pieces[lado_a_mover][B];
+    while (t1){
+        casa = Bitboard::bitscan(t1);
+        t1 &= Bitboard::not_mask[casa];
+        #ifdef USE_PEXT
+            ataques_deslizantes = Gen::bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])] & Bitboard::bit_lados[contraLado];
+        #else
+            ataques_deslizantes = Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])] & Bitboard::bit_lados[contraLado];
+        #endif
+        while (ataques_deslizantes){
+            casa_destino = Bitboard::bitscan(ataques_deslizantes);
+            ataques_deslizantes &= Bitboard::not_mask[casa_destino];
+            adicionar_captura(casa, casa_destino, Values::bx[Bitboard::tabuleiro[casa_destino]]);
+        }
+    }
+
+    // 4. capturas de torre
+    t1 = Bitboard::bit_pieces[lado_a_mover][T];
+    while (t1){
+        casa = Bitboard::bitscan(t1);
+        t1 &= Bitboard::not_mask[casa];
+        #ifdef USE_PEXT
+            ataques_deslizantes = Gen::bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])] & Bitboard::bit_lados[contraLado];
+        #else
+            ataques_deslizantes = Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])] & Bitboard::bit_lados[contraLado];
+        #endif
+        while (ataques_deslizantes){
+            casa_destino = Bitboard::bitscan(ataques_deslizantes);
+            ataques_deslizantes &= Bitboard::not_mask[casa_destino];
+            adicionar_captura(casa, casa_destino, Values::tx[Bitboard::tabuleiro[casa_destino]]);
+        }
+    }
+
+    // 5. capturas de dama
+    t1 = Bitboard::bit_pieces[lado_a_mover][D];
+    while (t1){
+        casa = Bitboard::bitscan(t1);
+        t1 &= Bitboard::not_mask[casa];
+        #ifdef USE_PEXT
+            ataques_deslizantes = (bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])] | bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])]) & Bitboard::bit_lados[contraLado];
+        #else
+            ataques_deslizantes = (Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])] | Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])]) & Bitboard::bit_lados[contraLado];
+        #endif
+        while (ataques_deslizantes){
+            casa_destino = Bitboard::bitscan(ataques_deslizantes);
+            ataques_deslizantes &= Bitboard::not_mask[casa_destino];
+            adicionar_captura(casa, casa_destino, Values::dx[Bitboard::tabuleiro[casa_destino]]);
+        }
+    }
+
+    // 6. capturas de rei
+    casa = Bitboard::bitscan(Bitboard::bit_pieces[lado_a_mover][R]);
+    t1 = Gen::bit_moves_rei[casa] & Bitboard::bit_lados[contraLado];
+    while (t1){
+        casa_destino = Bitboard::bitscan(t1);
+        t1 &= Bitboard::not_mask[casa_destino];
+        adicionar_captura(casa, casa_destino, Values::rx[Bitboard::tabuleiro[casa_destino]]);
+    }
+
+    Game::qntt_lances_totais[Game::ply + 1] = mc;
+}
+
+void Gen::gerar_silenciosos(const int lado_a_mover, const int contraLado){
+    int casa, casa_destino;
+    Bitboard::u64 t1, t2, t3;
+    Bitboard::u64 ataques_deslizantes;
+
+    // Anexa ao final do bloco de capturas já gerado.
+    mc = Game::qntt_lances_totais[Game::ply + 1];
+
+    gerar_roques();
+
+    // 1. avanços de peão (incluindo promoções silenciosas Q+N)
+    if (lado_a_mover == BRANCAS){
+        t3 = Bitboard::bit_pieces[BRANCAS][P] & ~(Bitboard::bit_total>>8);
+    }
+    else{
+        t3 = Bitboard::bit_pieces[PRETAS][P] & ~(Bitboard::bit_total<<8);
+    }
     while (t3){
         casa = Bitboard::bitscan(t3);
         t3 &= Bitboard::not_mask[casa];
@@ -545,146 +628,93 @@ void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
         }
         else{
             adicionar_lance(casa, casa_destino);
-
-            // 1.4.1 avanço duplo (a double push can never reach the back rank)
             if (Bitboard::fileiras[lado_a_mover][casa] == 1 && Bitboard::tabuleiro[peao_duas_casas[lado_a_mover][casa]] == VAZIO){
                 adicionar_lance(casa, peao_duas_casas[lado_a_mover][casa]);
             }
         }
     }
 
-    // 2. gera lances de cavalo
+    // 2. lances silenciosos de cavalo
     t1 = Bitboard::bit_pieces[lado_a_mover][C];
     while (t1){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
-
-        // 2.1 gera capturas do cavalo
-        t2 = Gen::bit_moves_cavalo[casa] & Bitboard::bit_lados[contraLado];
-        while (t2){
-            casa_destino = Bitboard::bitscan(t2);
-            t2 &= Bitboard::not_mask[casa_destino];
-
-            adicionar_captura(casa, casa_destino, Values::cx[Bitboard::tabuleiro[casa_destino]]);
-        }
-
-        // 2.2 gera lances de cavalo
         t2 = Gen::bit_moves_cavalo[casa] & ~Bitboard::bit_total;
         while(t2){
             casa_destino = Bitboard::bitscan(t2);
             t2 &= Bitboard::not_mask[casa_destino];
-
             adicionar_lance(casa, casa_destino);
         }
     }
 
-    // 3. gera lances de bispo
+    // 3. lances silenciosos de bispo
     t1 = Bitboard::bit_pieces[lado_a_mover][B];
     while (t1){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
-        
         #ifdef USE_PEXT
-            ataques_deslizantes = Gen::bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])];
+            ataques_deslizantes = Gen::bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])] & ~Bitboard::bit_total;
         #else
-            ataques_deslizantes = Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])];
+            ataques_deslizantes = Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])] & ~Bitboard::bit_total;
         #endif
-
-
         while (ataques_deslizantes){
             casa_destino = Bitboard::bitscan(ataques_deslizantes);
             ataques_deslizantes &= Bitboard::not_mask[casa_destino];
-
-            if (Bitboard::mask[casa_destino] & Bitboard::bit_total){
-                if (Bitboard::mask[casa_destino] & Bitboard::bit_lados[contraLado]){
-                    adicionar_captura(casa, casa_destino, Values::bx[Bitboard::tabuleiro[casa_destino]]);
-                }
-                
-                continue;
-            }
-
             adicionar_lance(casa, casa_destino);
         }
     }
 
-    // 4. gera lances de torre
+    // 4. lances silenciosos de torre
     t1 = Bitboard::bit_pieces[lado_a_mover][T];
     while (t1){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
-
         #ifdef USE_PEXT
-            ataques_deslizantes = Gen::bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])];
+            ataques_deslizantes = Gen::bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])] & ~Bitboard::bit_total;
         #else
-            ataques_deslizantes = Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])];
+            ataques_deslizantes = Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])] & ~Bitboard::bit_total;
         #endif
-
         while (ataques_deslizantes){
             casa_destino = Bitboard::bitscan(ataques_deslizantes);
             ataques_deslizantes &= Bitboard::not_mask[casa_destino];
-
-            if (Bitboard::mask[casa_destino] & Bitboard::bit_total){
-                if (Bitboard::mask[casa_destino] & Bitboard::bit_lados[contraLado]){
-                    adicionar_captura(casa, casa_destino, Values::tx[Bitboard::tabuleiro[casa_destino]]);
-                }
-
-                continue;
-            }
-
             adicionar_lance(casa, casa_destino);
         }
     }
 
-    // 5. gera lances de dama
+    // 5. lances silenciosos de dama
     t1 = Bitboard::bit_pieces[lado_a_mover][D];
     while (t1){
         casa = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa];
-
         #ifdef USE_PEXT
-            ataques_deslizantes = bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])] | bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])];
+            ataques_deslizantes = (bit_magicas_bispo[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_bispo[casa])] | bit_magicas_torre[casa][_pext_u64(Bitboard::bit_total, bit_casas_relevantes_torres[casa])]) & ~Bitboard::bit_total;
         #else
-            ataques_deslizantes = Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])] | Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])];
+            ataques_deslizantes = (Gen::bit_magicas_bispo[casa][((Bitboard::bit_total & bit_casas_relevantes_bispo[casa]) * Magics::magicas_bispos[casa]) >> (Magics::bits_indices_bispos[casa])] | Gen::bit_magicas_torre[casa][((Bitboard::bit_total & bit_casas_relevantes_torres[casa]) * Magics::magicas_torres[casa]) >> (Magics::bits_indices_torres[casa])]) & ~Bitboard::bit_total;
         #endif
-
         while (ataques_deslizantes){
             casa_destino = Bitboard::bitscan(ataques_deslizantes);
             ataques_deslizantes &= Bitboard::not_mask[casa_destino];
-
-            if (Bitboard::mask[casa_destino] & Bitboard::bit_total){
-                if (Bitboard::mask[casa_destino] & Bitboard::bit_lados[contraLado]){
-                    adicionar_captura(casa, casa_destino, Values::dx[Bitboard::tabuleiro[casa_destino]]);
-                }
-
-                continue;
-            }
-
             adicionar_lance(casa, casa_destino);
         }
     }
 
-    // 6. gera lances de rei
+    // 6. lances silenciosos de rei
     casa = Bitboard::bitscan(Bitboard::bit_pieces[lado_a_mover][R]);
-
-    // 6.1 gera capturas
-    t1 = Gen::bit_moves_rei[casa] & Bitboard::bit_lados[contraLado];
-    while (t1){
-        casa_destino = Bitboard::bitscan(t1);
-        t1 &= Bitboard::not_mask[casa_destino];
-
-        adicionar_captura(casa, casa_destino, Values::rx[Bitboard::tabuleiro[casa_destino]]);
-    }
-
-    // 6.2 gera lances sem capturas
     t1 = Gen::bit_moves_rei[casa] & ~Bitboard::bit_total;
     while (t1){
         casa_destino = Bitboard::bitscan(t1);
         t1 &= Bitboard::not_mask[casa_destino];
-
         adicionar_lance(casa, casa_destino);
     }
 
     Game::qntt_lances_totais[Game::ply + 1] = mc;
+}
+
+// Preserves the full-list API for perft and non-search callers. Staged search
+// uses `gerar_capturas_busca` + `gerar_silenciosos` directly.
+void Gen::gerar_lances(const int lado_a_mover, const int contraLado){
+    gerar_capturas_busca(lado_a_mover, contraLado);
+    gerar_silenciosos(lado_a_mover, contraLado);
 }
 
 void Gen::gerar_capturas(const int lado_a_mover, const int contraLado){

--- a/src/gen.h
+++ b/src/gen.h
@@ -44,7 +44,21 @@ namespace Gen{
     extern Bitboard::u64 bit_peao_defende[LADOS][CASAS_DO_TABULEIRO];
 
     void init_lookup_tables();
+    // Full pseudo-legal move list (captures + quiets). Used by perft and by
+    // anything outside `Search::pesquisa` that wants the whole list at once.
     void gerar_lances(const int lado_a_mover, const int contraLado);
+    // Captures only (including EP and pawn capture-promotions with Q+N
+    // variants). Emits Q+N for capture-promos; contrast with `gerar_capturas`
+    // below which emits Q-only for qsearch. Used as the first stage of
+    // `pesquisa`'s lazy move generation.
+    void gerar_capturas_busca(const int lado_a_mover, const int contraLado);
+    // Quiet moves only (castling, pawn pushes including quiet promos, and all
+    // non-capture piece moves). Appends onto an existing capture list by
+    // starting from `qntt_lances_totais[ply+1]`; must run after a capture
+    // generator that set that boundary.
+    void gerar_silenciosos(const int lado_a_mover, const int contraLado);
+    // Qsearch captures (Q-only promo, no EP). Do not confuse with
+    // `gerar_capturas_busca`.
     void gerar_capturas(const int lado_a_mover, const int contraLado);
     unsigned long long perft_node(int profunidade);
     unsigned long long perft(int profunidade);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -228,13 +228,23 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
         check = 1;
     }
 
-    Gen::gerar_lances(Game::lado, Game::xlado);
+    // Staged move generation: captures first, quiets only if no cutoff.
+    // IID needs the whole list up-front to score quiet moves (its job is to
+    // improve quiet-move ordering at deep PV nodes with no TT hit), so the
+    // IID path falls back to full generation and pays the upfront cost.
+    const bool iid_path = !tt_hit && (profundidade > PROFUNDIDADE_CONDICAO_IID) && pv;
 
-    if (tt_hit){
-        Hash::adicionar_pontuacao_de_hash(); // reuse probe result for move ordering
-    } else if (profundidade > PROFUNDIDADE_CONDICAO_IID && pv){
+    if (iid_path){
+        Gen::gerar_lances(Game::lado, Game::xlado);
         adicionar_pontuacao_iid(alpha, beta, profundidade);
+    } else {
+        Gen::gerar_capturas_busca(Game::lado, Game::xlado);
+        if (tt_hit){
+            Hash::adicionar_pontuacao_de_hash(); // may find the TT move here
+        }
     }
+
+    bool quiets_generated = iid_path; // iid_path already emitted quiets too
 
     int lances_legais_na_posicao = 0;
     int score_candidato;
@@ -242,7 +252,20 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
 
     bool pesquisandoPV = true;
 
-    for (int candidato = Game::qntt_lances_totais[Game::ply]; candidato < Game::qntt_lances_totais[Game::ply + 1]; ++candidato){
+    for (int candidato = Game::qntt_lances_totais[Game::ply]; ; ++candidato){
+        // Exhausted captures? Lazily generate quiets and re-boost the TT move
+        // if it happens to be quiet (adicionar_pontuacao_de_hash is a no-op
+        // when called a second time after already scoring a capture).
+        if (candidato >= Game::qntt_lances_totais[Game::ply + 1]){
+            if (quiets_generated) break;
+            Gen::gerar_silenciosos(Game::lado, Game::xlado);
+            if (tt_hit){
+                Hash::adicionar_pontuacao_de_hash();
+            }
+            quiets_generated = true;
+            if (candidato >= Game::qntt_lances_totais[Game::ply + 1]) break;
+        }
+
         ordenar_lances(candidato);
 
         // verifica se o lance é legal

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,7 +179,22 @@ void adicionar_pontuacao_iid(int alpha, int beta, int profundidade){
     for (int candidato = Game::qntt_lances_totais[Game::ply]; candidato < Game::qntt_lances_totais[Game::ply + 1]; ++candidato){
         Gen::lista_de_lances[candidato].score = -Search::pesquisa(-beta, -alpha, profundidade REDUCAO_IID, false);
     }
-}   
+}
+
+// Parameterized variant of Hash::adicionar_pontuacao_de_hash. The namespace
+// version reads Hash::hash_{inicio,destino,promove} globals which any nested
+// hash_lookup (inside recursive pesquisa) will stomp — so once we've recursed
+// through captures, boosting by globals aims at a descendant's TT move, not
+// ours. This version takes the move by value so stomping is impossible.
+static void score_tt_move(const int tt_inicio, const int tt_destino, const int tt_promove){
+    for (int lance = Game::qntt_lances_totais[Game::ply]; lance < Game::qntt_lances_totais[Game::ply + 1]; lance++){
+        const Gen::lance &m = Gen::lista_de_lances[lance];
+        if (m.inicio == tt_inicio && m.destino == tt_destino && m.promove == tt_promove){
+            Gen::lista_de_lances[lance].score = PONTUACAO_HASH;
+            return;
+        }
+    }
+}
 
 int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
     if (Game::ply && Game::checar_repeticoes()){
@@ -215,6 +230,16 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
     const int  tt_depth = tt_hit ? Hash::hash_depth : -1;
     const int  tt_bound = tt_hit ? Hash::hash_bound : TT_BOUND_NONE;
 
+    // Snapshot the TT move before any recursion can call hash_lookup and
+    // stomp the Hash::hash_* globals. The second adicionar_pontuacao_de_hash
+    // call (after lazy quiet generation) runs after we've recursed into
+    // child searches for captures, each of which overwrites those globals
+    // with their own TT entries — without this snapshot the second call
+    // boosts an arbitrary move from a descendant position.
+    const int tt_mv_inicio  = tt_hit ? Hash::hash_inicio  : 0;
+    const int tt_mv_destino = tt_hit ? Hash::hash_destino : 0;
+    const int tt_mv_promove = tt_hit ? Hash::hash_promove : 0;
+
     // TT cutoff: non-root, non-PV nodes only, stored depth must be >= current.
     if (tt_hit && !pv && Game::ply > 0 && tt_depth >= profundidade){
         if (tt_bound == TT_BOUND_EXACT)                      return tt_score;
@@ -228,23 +253,39 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
         check = 1;
     }
 
-    // Staged move generation: captures first, quiets only if no cutoff.
-    // IID needs the whole list up-front to score quiet moves (its job is to
-    // improve quiet-move ordering at deep PV nodes with no TT hit), so the
-    // IID path falls back to full generation and pays the upfront cost.
+    // Staged move generation.
+    // - IID: needs the whole list up-front to score quiet moves, so full gen.
+    // - TT hit whose destination holds an enemy piece: almost certainly a
+    //   capture, so lazy quiet gen is safe (TT capture lives in captures
+    //   list, gets boosted, tried first; if it cuts off we skip quiet gen).
+    // - TT hit whose destination is empty: either a quiet move or EP. Full
+    //   gen so the TT quiet is in the list and gets boosted to the top.
+    //   (Phase A regressed here by searching all captures before discovering
+    //   the TT quiet — this branch is what Phase B adds to prevent that.)
+    // - No TT hit: pure lazy (captures now, quiets on exhaustion).
     const bool iid_path = !tt_hit && (profundidade > PROFUNDIDADE_CONDICAO_IID) && pv;
+
+    bool quiets_generated;
 
     if (iid_path){
         Gen::gerar_lances(Game::lado, Game::xlado);
         adicionar_pontuacao_iid(alpha, beta, profundidade);
+        quiets_generated = true;
+    } else if (tt_hit){
+        const bool tt_dest_has_enemy = Bitboard::mask[tt_mv_destino] & Bitboard::bit_lados[Game::xlado];
+        if (tt_dest_has_enemy){
+            Gen::gerar_capturas_busca(Game::lado, Game::xlado);
+            score_tt_move(tt_mv_inicio, tt_mv_destino, tt_mv_promove);
+            quiets_generated = false;
+        } else {
+            Gen::gerar_lances(Game::lado, Game::xlado);
+            score_tt_move(tt_mv_inicio, tt_mv_destino, tt_mv_promove);
+            quiets_generated = true;
+        }
     } else {
         Gen::gerar_capturas_busca(Game::lado, Game::xlado);
-        if (tt_hit){
-            Hash::adicionar_pontuacao_de_hash(); // may find the TT move here
-        }
+        quiets_generated = false;
     }
-
-    bool quiets_generated = iid_path; // iid_path already emitted quiets too
 
     int lances_legais_na_posicao = 0;
     int score_candidato;
@@ -258,10 +299,11 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
         // when called a second time after already scoring a capture).
         if (candidato >= Game::qntt_lances_totais[Game::ply + 1]){
             if (quiets_generated) break;
+            // Reach here only when there was no TT hit, or when TT hit had
+            // an enemy-occupied destination (capture path). In both cases
+            // the TT move — if any — was already discovered and boosted
+            // during the capture stage, so no re-boost is needed here.
             Gen::gerar_silenciosos(Game::lado, Game::xlado);
-            if (tt_hit){
-                Hash::adicionar_pontuacao_de_hash();
-            }
             quiets_generated = true;
             if (candidato >= Game::qntt_lances_totais[Game::ply + 1]) break;
         }


### PR DESCRIPTION
Adiciona lazy generation de lances na pesquisa:
1 - Pesquisa usa `gerar_capturas_busca` para pesquisar primeiro capturas (que tem maior probabilidade de gerar um beta-cutoff)
2 - Caso não haja um beta-cutoff dentre as capturas, pesquisa usa `gerar_silenciosos` para gerar demais lances.

Ordem de pesquisa:
a - IID
b - capturas em transposições (transposition-table hit)
c - lances silenciosos em transposições (transposition-table hit)
d - restante dos lances

Essa alteração aumentou 10% o NPS e reduziu certa de 1% a quantidade de nós visitados por depth