### PR TITLE
Null move pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -196,7 +196,7 @@ static void score_tt_move(const int tt_inicio, const int tt_destino, const int t
     }
 }
 
-int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
+int Search::pesquisa(int alpha, int beta, int profundidade, bool pv, bool null_permitido){
     if (Game::ply && Game::checar_repeticoes()){
         return VALOR_EMPATE;
     }
@@ -251,6 +251,31 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv){
 
     if (Attacks::casa_esta_sendo_atacada(Game::xlado, Bitboard::bitscan(Bitboard::bit_pieces[Game::lado][R]))){
         check = 1;
+    }
+
+    // Null-move pruning. If we hand the opponent a free move and they still
+    // can't beat beta with a reduced-depth search, our actual move can only
+    // produce an even better score — return beta. Guarded against:
+    //   - in-check: passing would leave the king in check (illegal).
+    //   - PV nodes: PVS expects exact scores; null-move's null-window result
+    //     isn't usable.
+    //   - already-null nodes: prevent two null-moves in a row, which would
+    //     just be a deeper skip equivalent to a single bigger R.
+    //   - low depth: at depth-1-R below 1 we'd hit qsearch, no info gained.
+    //   - zugzwang risk: if we have only pawns + king, "passing" is often
+    //     strictly worse than any move (opposition, etc.), so the null-move
+    //     bet is unsafe.
+    if (!check && !pv && null_permitido
+        && profundidade >= 3
+        && (Bitboard::bit_pieces[Game::lado][C] | Bitboard::bit_pieces[Game::lado][B]
+          | Bitboard::bit_pieces[Game::lado][T] | Bitboard::bit_pieces[Game::lado][D])){
+        Update::fazer_null_move();
+        const int score_null = -pesquisa(-beta, -beta + 1, profundidade - 1 - R_NULL_MOVE, false, false);
+        Update::desfaz_null_move();
+
+        if (score_null >= beta){
+            return beta;
+        }
     }
 
     // Staged move generation.
@@ -405,7 +430,11 @@ void Search::pensar(bool verbose){
     setjmp(env);
     if (parar_pesquisa){
         while (Game::ply){
-            Update::desfaz_lance();
+            // The unwinder must dispatch to desfaz_null_move for any
+            // null-move frame on the stack. Naively calling desfaz_lance
+            // on the (0, 0, captura=VAZIO) sentinel would corrupt the
+            // bitboards and Zobrist key (mover_piece(0, 0) clears tabuleiro[0]).
+            Update::desfaz_lance_ou_null();
         }
 
         return;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -73,8 +73,12 @@ int pesquisa_quiescence(int inicio, const int destino){
         recapturas_feitas++;
         recaptura++;
 
-        Search::lances_avaliados++;
-
+        // No node-counter increment here. `pesquisa_rapida` (the qsearch
+        // entry) counts each qsearch invocation; the recapture loop is part
+        // of a SEE-style evaluation, not independent search nodes. Counting
+        // every recapture step inflated `lances_avaliados` and made the time
+        // poll (`lances_avaliados & VERIFICACAO_DE_LANCES`) fire more often
+        // than the search-node-count interpretation suggests.
         menor_recaptura = Attacks::menor_atacante(Game::lado, Game::xlado, destino); // ordena por MVA/LVV
 
         if (menor_recaptura > -1){

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -273,8 +273,9 @@ int Search::pesquisa(int alpha, int beta, int profundidade, bool pv, bool null_p
         && profundidade >= 3
         && (Bitboard::bit_pieces[Game::lado][C] | Bitboard::bit_pieces[Game::lado][B]
           | Bitboard::bit_pieces[Game::lado][T] | Bitboard::bit_pieces[Game::lado][D])){
+        const int reducao_null = (profundidade >= R_NULL_DEPTH_THRESH) ? R_NULL_HIGH : R_NULL_LOW;
         Update::fazer_null_move();
-        const int score_null = -pesquisa(-beta, -beta + 1, profundidade - 1 - R_NULL_MOVE, false, false);
+        const int score_null = -pesquisa(-beta, -beta + 1, profundidade - 1 - reducao_null, false, false);
         Update::desfaz_null_move();
 
         if (score_null >= beta){

--- a/src/search.h
+++ b/src/search.h
@@ -14,7 +14,11 @@ namespace Search{
     extern Gen::lance killers_secundarios[MAX_PLY];
 
     void pensar(bool verbose);
-    int pesquisa(int alpha, int beta, int profundidade, bool pv);
+    // null_permitido = false on the immediate child of a null-move so we don't
+    // recurse two null-moves in a row (which would just compound the depth
+    // skip with no information). Defaults to true so existing call sites
+    // (real-move recursion, IID, qsearch) keep their current behavior.
+    int pesquisa(int alpha, int beta, int profundidade, bool pv, bool null_permitido = true);
 };
 
 #endif

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -246,6 +246,14 @@ void Update::fazer_null_move(){
     j->hash      = Hash::chaveAtual;
     j->lock      = Hash::lockAtual;
 
+    // Seed the child ply's move-list start. Real moves go through
+    // gerar_lances at the parent before any child enters, so qntt[ply+1] is
+    // always written by the parent. Null-move skips parent's gen entirely,
+    // so without this seed the child reads a stale value left by a previous
+    // iteration and writes its moves to a region that may overlap another
+    // active ply's list — corrupting moves that are about to be applied.
+    Game::qntt_lances_totais[Game::ply + 1] = Game::qntt_lances_totais[Game::ply];
+
     Game::ply++;
     Game::hply++;
     Game::cinquenta++;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -231,6 +231,55 @@ void Update::desfaz_captura(){
     adicionar_piece(Game::xlado, Game::lista_do_jogo[Game::hply].captura, Game::lista_do_jogo[Game::hply].destino);
 }
 
+void Update::fazer_null_move(){
+    // Push a sentinel history entry. EP availability in `gerar_en_passant`
+    // is detected by reading the previous entry and checking for a double
+    // pawn push — inicio == destino == 0 satisfies neither condition, so EP
+    // gets correctly cleared for the side that gains the tempo.
+    Game::jogo *j = &Game::lista_do_jogo[Game::hply];
+    j->inicio    = 0;
+    j->destino   = 0;
+    j->promove   = P;
+    j->captura   = VAZIO;
+    j->cinquenta = Game::cinquenta;
+    j->roque     = Game::roque;
+    j->hash      = Hash::chaveAtual;
+    j->lock      = Hash::lockAtual;
+
+    Game::ply++;
+    Game::hply++;
+    Game::cinquenta++;
+
+    Game::lado  ^= 1;
+    Game::xlado ^= 1;
+    // Zobrist key intentionally not updated: capizero stores side-to-move
+    // implicitly via per-side TT tables (`hashpos[BRANCAS]` vs `hashpos[PRETAS]`),
+    // and the key has no castling/EP component to clear.
+}
+
+void Update::desfaz_null_move(){
+    Game::lado  ^= 1;
+    Game::xlado ^= 1;
+    Game::ply--;
+    Game::hply--;
+
+    Game::jogo *j = &Game::lista_do_jogo[Game::hply];
+    Game::cinquenta = j->cinquenta;
+    Game::roque     = j->roque;
+}
+
+void Update::desfaz_lance_ou_null(){
+    const Game::jogo *last = &Game::lista_do_jogo[Game::hply - 1];
+    // Real moves never have inicio == destino (no chess move is to its own
+    // square), so (0, 0, captura == VAZIO) uniquely identifies our null-move
+    // sentinel.
+    if (last->inicio == 0 && last->destino == 0 && last->captura == VAZIO){
+        desfaz_null_move();
+    } else {
+        desfaz_lance();
+    }
+}
+
 int Update::fazer_captura(const int inicio, const int destino){
     Game::lista_do_jogo[Game::hply].inicio = inicio;
     Game::lista_do_jogo[Game::hply].destino = destino;

--- a/src/update.h
+++ b/src/update.h
@@ -13,6 +13,16 @@ namespace Update{
     void setar_posicao(char posicao[80], char lado_a_jogar[1], char roques[4], char casa_en_passant[2], char hm[4], char fm[4]);
     void desfaz_captura();
     void desfaz_lance();
+    // Null-move support for forward pruning. Pushes a sentinel history entry
+    // (inicio == destino == 0, captura == VAZIO, promove == P) so EP detection
+    // — which reads the previous lista_do_jogo entry to test for a double
+    // pawn push — never mistakes a null-move parent for one. The sentinel is
+    // also what `desfaz_lance_ou_null` keys off to dispatch the right undo.
+    void fazer_null_move();
+    void desfaz_null_move();
+    // Polymorphic undo that picks `desfaz_null_move` for null-move history
+    // entries and `desfaz_lance` otherwise. Used by the time-abort unwinder.
+    void desfaz_lance_ou_null();
 };
 
 #endif

--- a/src/values.h
+++ b/src/values.h
@@ -56,10 +56,15 @@ namespace Values{
 
 	#define REDUCAO_LMR 3
 
-	// Null-move pruning depth reduction. R=2 is conservative (Stockfish-style
-	// dynamic R is the next-level tweak); R=3 is more aggressive but risks
-	// missing tactical refutations at the boundary depth.
-	#define R_NULL_MOVE 2
+	// Null-move pruning depth reduction. Dynamic R: heavier pruning at deep
+	// depths where the search tree is huge and the marginal cost of missing
+	// tactics is offset by the breadth gain; lighter pruning near the leaves
+	// where the reduced-depth subsearch needs to retain enough resolution
+	// to be informative. With R_NULL_HIGH = 3 and the threshold at 6, a
+	// depth-6 null-move recurses at depth 2 (still beats qsearch by 2 plies).
+	#define R_NULL_LOW          2
+	#define R_NULL_HIGH         3
+	#define R_NULL_DEPTH_THRESH 6
 
 	// ordenação de capturas
 	#define SCORE_CAPTURAS_DESVANTAJOSAS SCORE_CAPTURAS_D

--- a/src/values.h
+++ b/src/values.h
@@ -56,6 +56,11 @@ namespace Values{
 
 	#define REDUCAO_LMR 3
 
+	// Null-move pruning depth reduction. R=2 is conservative (Stockfish-style
+	// dynamic R is the next-level tweak); R=3 is more aggressive but risks
+	// missing tactical refutations at the boundary depth.
+	#define R_NULL_MOVE 2
+
 	// ordenação de capturas
 	#define SCORE_CAPTURAS_DESVANTAJOSAS SCORE_CAPTURAS_D
 	#define SCORE_DE_CAPTURA_VANTAJOSAS SCORE_CAPTURAS_V


### PR DESCRIPTION
Este PR implementa null-move-pruning com uma step function para determinar o valor de R.

```
Results of candidate vs baseline (10+0.1, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: 24.08 +/- 10.73, nElo: 29.92 +/- 13.28
LOS: 100.00 %, DrawRatio: 35.97 %, PairsRatio: 1.29
Games: 2630, Wins: 1005, Losses: 823, Draws: 802, Points: 1406.0 (53.46 %)
Ptnml(0-2): [110, 257, 473, 291, 184], WL/DD Ratio: 2.72
LLR: 2.97 (100.9%) (-2.94, 2.94) [0.00, 5.00]
```