### PR TITLE
Tapered eval

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -1,6 +1,7 @@
 #include "bitboard.h"
 
 #include "update.h"
+#include "eval.h"
 
 #include <string.h>
 #include <stdint.h>
@@ -208,6 +209,10 @@ void Bitboard::init_board(){
     memset(bit_pieces, 0, sizeof(bit_pieces));
     memset(bit_lados, 0, sizeof(bit_lados));
     bit_total = 0;
+
+    // Reset incremental phase counter before the per-square adicionar_piece
+    // loop accumulates it back to PHASE_MAX for the starting position.
+    Eval::fase_valor = 0;
 
     for (int casa = 0; casa < CASAS_DO_TABULEIRO; ++casa) {
         tabuleiro[casa] = VAZIO;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -6,7 +6,6 @@
 
 
 Eval::Score Eval::score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
-int Eval::reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
 int Eval::passados[LADOS][CASAS_DO_TABULEIRO];
 
 int Eval::peao_mat[LADOS];
@@ -37,12 +36,20 @@ void Eval::init_eval_tables(){
         const int dama_w   = Values::dama_score[x] + VALOR_DAMA;
         const int rei_w    = Values::rei_score[x];
 
+        // King PST is the first natively-tapered term: mg = rei_score
+        // (cares about safety / the back rank), eg = rei_finais_score
+        // (cares about activity / centralization). The legacy code applied
+        // a hard conditional swap based on enemy-queen presence; tapered
+        // eval replaces that with smooth phase interpolation.
+        const int rei_w_eg = Values::rei_finais_score[x];
+        const int rei_b_eg = Values::rei_finais_score[Consts::flip[x]];
+
         score_casas[BRANCAS][P][x] = make_score(peao_w,   peao_w);
         score_casas[BRANCAS][C][x] = make_score(cavalo_w, cavalo_w);
         score_casas[BRANCAS][B][x] = make_score(bispo_w,  bispo_w);
         score_casas[BRANCAS][T][x] = make_score(torre_w,  torre_w);
         score_casas[BRANCAS][D][x] = make_score(dama_w,   dama_w);
-        score_casas[BRANCAS][R][x] = make_score(rei_w,    rei_w);
+        score_casas[BRANCAS][R][x] = make_score(rei_w,    rei_w_eg);
 
         const int peao_b   = Values::peao_score[Consts::flip[x]] + VALOR_PEAO;
         const int cavalo_b = Values::cavalo_score[Consts::flip[x]] + VALOR_CAVALO;
@@ -56,15 +63,7 @@ void Eval::init_eval_tables(){
         score_casas[PRETAS][B][x] = make_score(bispo_b,  bispo_b);
         score_casas[PRETAS][T][x] = make_score(torre_b,  torre_b);
         score_casas[PRETAS][D][x] = make_score(dama_b,   dama_b);
-        score_casas[PRETAS][R][x] = make_score(rei_b,    rei_b);
-
-        // reis_score_finais is the eg-king-PST delta from rei_score to
-        // rei_finais_score. While we still apply it as a conditional swap
-        // (queen-presence based), keep storing the legacy delta. Future
-        // pass: drop this entirely and bake rei_finais_score into the eg
-        // half of score_casas[R] directly.
-        reis_score_finais[BRANCAS][x] = Values::rei_finais_score[x] - rei_w;
-        reis_score_finais[PRETAS][x]  = Values::rei_finais_score[x] - rei_b;
+        score_casas[PRETAS][R][x] = make_score(rei_b,    rei_b_eg);
 
         passados[BRANCAS][x] = Values::peao_passado_score[Consts::flip[x]];
         passados[PRETAS][x] = Values::peao_passado_score[x];
@@ -199,35 +198,29 @@ int Eval::avaliar(){
         }
     }
 
-    if (Bitboard::bit_pieces[PRETAS][D] == 0){
-        const int rei_eg = reis_score_finais[BRANCAS][Bitboard::bitscan(Bitboard::bit_pieces[BRANCAS][R])];
-        score[BRANCAS] += make_score(rei_eg, rei_eg);
+    // Pawn shield is a midgame-only concept (king wants to stay tucked
+    // behind pawns while the opponent has heavy pieces; in the endgame
+    // the king should be active). The legacy code gated this on
+    // `enemy_queen_present` as a binary proxy for "still mg"; with the
+    // king PST now natively tapered, we just apply the shield to the mg
+    // half and let the phase interpolation fade it out as material thins.
+    int shield_w = 0;
+    if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_do_rei){
+        shield_w = peao_ala_do_rei[BRANCAS];
     }
-    else{
-        int shield = 0;
-        if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_do_rei){
-            shield = peao_ala_do_rei[BRANCAS];
-        }
-        else if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_da_dama){
-            shield = peao_ala_da_dama[BRANCAS];
-        }
-        score[BRANCAS] += make_score(shield, shield);
+    else if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_da_dama){
+        shield_w = peao_ala_da_dama[BRANCAS];
     }
+    score[BRANCAS] += make_score(shield_w, 0);
 
-    if (Bitboard::bit_pieces[BRANCAS][D] == 0){
-        const int rei_eg = reis_score_finais[PRETAS][Bitboard::bitscan(Bitboard::bit_pieces[PRETAS][R])];
-        score[PRETAS] += make_score(rei_eg, rei_eg);
+    int shield_b = 0;
+    if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_do_rei){
+        shield_b = peao_ala_do_rei[PRETAS];
     }
-    else {
-        int shield = 0;
-        if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_do_rei){
-            shield = peao_ala_do_rei[PRETAS];
-        }
-        else if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_da_dama){
-            shield = peao_ala_da_dama[PRETAS];
-        }
-        score[PRETAS] += make_score(shield, shield);
+    else if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_da_dama){
+        shield_b = peao_ala_da_dama[PRETAS];
     }
+    score[PRETAS] += make_score(shield_b, 0);
 
     // Side-to-move difference, then unpack and interpolate.
     const Score diff = score[Game::lado] - score[Game::xlado];

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -5,39 +5,66 @@
 #include "game.h"
 
 
-int Eval::score_casas_mg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
-int Eval::score_casas_eg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+Eval::Score Eval::score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
 int Eval::reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
 int Eval::passados[LADOS][CASAS_DO_TABULEIRO];
 
 int Eval::peao_mat[LADOS];
 int Eval::piece_mat[LADOS];
 
+int Eval::fase_valor = 0;
+
+// Phase weight per piece type, indexed by the {P, C, B, T, D, R} encoding
+// in consts.h. Mirrors Values::PHASE_* macros — kept here as a contiguous
+// array so Update::adicionar_piece / Update::remover_piece can do a single
+// indexed load instead of a switch.
+const int Eval::phase_weights[6] = {
+    PHASE_PEAO, PHASE_CAVALO, PHASE_BISPO, PHASE_TORRE, PHASE_DAMA, PHASE_REI
+};
+
 int peao_ala_da_dama[LADOS],peao_ala_do_rei[LADOS];
 
 void Eval::init_eval_tables(){
+    // Phase 1 of the tapered-eval rollout still has mg = eg, so the packed
+    // score per square just duplicates the legacy single value into both
+    // halves. Future passes will differentiate (e.g. king PST: mg = rei_score,
+    // eg = rei_finais_score, dropping the conditional swap below).
     for (int x = 0; x < CASAS_DO_TABULEIRO; x++){
-        score_casas_mg[BRANCAS][P][x] = Values::peao_score[x] + VALOR_PEAO;
-        score_casas_mg[BRANCAS][C][x] = Values::cavalo_score[x] + VALOR_CAVALO;
-        score_casas_mg[BRANCAS][B][x] = Values::bispo_score[x] + VALOR_BISPO;
-        score_casas_mg[BRANCAS][T][x] = Values::torre_score[x] + VALOR_TORRE;
-        score_casas_mg[BRANCAS][D][x] = Values::dama_score[x] + VALOR_DAMA;
-        score_casas_mg[BRANCAS][R][x] = Values::rei_score[x];
+        const int peao_w   = Values::peao_score[x] + VALOR_PEAO;
+        const int cavalo_w = Values::cavalo_score[x] + VALOR_CAVALO;
+        const int bispo_w  = Values::bispo_score[x] + VALOR_BISPO;
+        const int torre_w  = Values::torre_score[x] + VALOR_TORRE;
+        const int dama_w   = Values::dama_score[x] + VALOR_DAMA;
+        const int rei_w    = Values::rei_score[x];
 
-        score_casas_mg[PRETAS][P][x] = Values::peao_score[Consts::flip[x]] + VALOR_PEAO;
-        score_casas_mg[PRETAS][C][x] = Values::cavalo_score[Consts::flip[x]] + VALOR_CAVALO;
-        score_casas_mg[PRETAS][B][x] = Values::bispo_score[Consts::flip[x]] + VALOR_BISPO;
-        score_casas_mg[PRETAS][T][x] = Values::torre_score[Consts::flip[x]] + VALOR_TORRE;
-        score_casas_mg[PRETAS][D][x] = Values::dama_score[Consts::flip[x]] + VALOR_DAMA;
-        score_casas_mg[PRETAS][R][x] = Values::rei_score[Consts::flip[x]];
+        score_casas[BRANCAS][P][x] = make_score(peao_w,   peao_w);
+        score_casas[BRANCAS][C][x] = make_score(cavalo_w, cavalo_w);
+        score_casas[BRANCAS][B][x] = make_score(bispo_w,  bispo_w);
+        score_casas[BRANCAS][T][x] = make_score(torre_w,  torre_w);
+        score_casas[BRANCAS][D][x] = make_score(dama_w,   dama_w);
+        score_casas[BRANCAS][R][x] = make_score(rei_w,    rei_w);
 
-        for (int p = 0; p < TIPOS_DE_PIECES; p++){
-            score_casas_eg[BRANCAS][p][x] = score_casas_mg[BRANCAS][p][x];
-            score_casas_eg[PRETAS][p][x]  = score_casas_mg[PRETAS][p][x];
-        }
+        const int peao_b   = Values::peao_score[Consts::flip[x]] + VALOR_PEAO;
+        const int cavalo_b = Values::cavalo_score[Consts::flip[x]] + VALOR_CAVALO;
+        const int bispo_b  = Values::bispo_score[Consts::flip[x]] + VALOR_BISPO;
+        const int torre_b  = Values::torre_score[Consts::flip[x]] + VALOR_TORRE;
+        const int dama_b   = Values::dama_score[Consts::flip[x]] + VALOR_DAMA;
+        const int rei_b    = Values::rei_score[Consts::flip[x]];
 
-        reis_score_finais[BRANCAS][x] = Values::rei_finais_score[x] - score_casas_mg[BRANCAS][R][x];
-        reis_score_finais[PRETAS][x] = Values::rei_finais_score[x] - score_casas_mg[PRETAS][R][x];
+        score_casas[PRETAS][P][x] = make_score(peao_b,   peao_b);
+        score_casas[PRETAS][C][x] = make_score(cavalo_b, cavalo_b);
+        score_casas[PRETAS][B][x] = make_score(bispo_b,  bispo_b);
+        score_casas[PRETAS][T][x] = make_score(torre_b,  torre_b);
+        score_casas[PRETAS][D][x] = make_score(dama_b,   dama_b);
+        score_casas[PRETAS][R][x] = make_score(rei_b,    rei_b);
+
+        // reis_score_finais is the eg-king-PST delta from rei_score to
+        // rei_finais_score. While we still apply it as a conditional swap
+        // (queen-presence based), keep storing the legacy delta. Future
+        // pass: drop this entirely and bake rei_finais_score into the eg
+        // half of score_casas[R] directly.
+        reis_score_finais[BRANCAS][x] = Values::rei_finais_score[x] - rei_w;
+        reis_score_finais[PRETAS][x]  = Values::rei_finais_score[x] - rei_b;
 
         passados[BRANCAS][x] = Values::peao_passado_score[Consts::flip[x]];
         passados[PRETAS][x] = Values::peao_passado_score[x];
@@ -45,12 +72,7 @@ void Eval::init_eval_tables(){
 }
 
 int Eval::fase(){
-    int phase = PHASE_CAVALO * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][C] | Bitboard::bit_pieces[PRETAS][C])
-              + PHASE_BISPO  * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][B] | Bitboard::bit_pieces[PRETAS][B])
-              + PHASE_TORRE  * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][T] | Bitboard::bit_pieces[PRETAS][T])
-              + PHASE_DAMA   * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][D] | Bitboard::bit_pieces[PRETAS][D]);
-    if (phase > PHASE_MAX) phase = PHASE_MAX;
-    return phase;
+    return (fase_valor > PHASE_MAX) ? PHASE_MAX : fase_valor;
 }
 
 void Eval::atualizar_materiais(){
@@ -114,8 +136,13 @@ int avaliar_torre(const int l, const int casa){
 }
 
 int Eval::avaliar(){
-    int mg_score[LADOS] = {0, 0};
-    int eg_score[LADOS] = {0, 0};
+    // Single packed accumulator per side. mg lives in the high 16 bits,
+    // eg in the low 16; both halves accumulate in lockstep through plain
+    // int32 addition. Single-valued bonuses (avaliar_peao, avaliar_torre,
+    // king PST swap, pawn shield) are wrapped via make_score(v, v) so the
+    // same delta lands in both halves. Future tapered terms differentiate
+    // by passing distinct mg/eg values to make_score.
+    Score score[LADOS] = {0, 0};
 
     peao_ala_da_dama[BRANCAS] = 0;
     peao_ala_do_rei[BRANCAS] = 0;
@@ -132,11 +159,9 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            mg_score[l] += score_casas_mg[l][P][casa];
-            eg_score[l] += score_casas_eg[l][P][casa];
+            score[l] += score_casas[l][P][casa];
             const int peao_b = avaliar_peao(l, casa);
-            mg_score[l] += peao_b;
-            eg_score[l] += peao_b;
+            score[l] += make_score(peao_b, peao_b);
         }
 
         t1 = Bitboard::bit_pieces[l][C];
@@ -144,8 +169,7 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            mg_score[l] += score_casas_mg[l][C][casa];
-            eg_score[l] += score_casas_eg[l][C][casa];
+            score[l] += score_casas[l][C][casa];
         }
 
         t1 = Bitboard::bit_pieces[l][B];
@@ -153,8 +177,7 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            mg_score[l] += score_casas_mg[l][B][casa];
-            eg_score[l] += score_casas_eg[l][B][casa];
+            score[l] += score_casas[l][B][casa];
         }
 
         t1 = Bitboard::bit_pieces[l][T];
@@ -162,11 +185,9 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            mg_score[l] += score_casas_mg[l][T][casa];
-            eg_score[l] += score_casas_eg[l][T][casa];
+            score[l] += score_casas[l][T][casa];
             const int torre_b = avaliar_torre(l, casa);
-            mg_score[l] += torre_b;
-            eg_score[l] += torre_b;
+            score[l] += make_score(torre_b, torre_b);
         }
 
         t1 = Bitboard::bit_pieces[l][D];
@@ -174,15 +195,13 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            mg_score[l] += score_casas_mg[l][D][casa];
-            eg_score[l] += score_casas_eg[l][D][casa];
+            score[l] += score_casas[l][D][casa];
         }
     }
 
     if (Bitboard::bit_pieces[PRETAS][D] == 0){
         const int rei_eg = reis_score_finais[BRANCAS][Bitboard::bitscan(Bitboard::bit_pieces[BRANCAS][R])];
-        mg_score[BRANCAS] += rei_eg;
-        eg_score[BRANCAS] += rei_eg;
+        score[BRANCAS] += make_score(rei_eg, rei_eg);
     }
     else{
         int shield = 0;
@@ -192,14 +211,12 @@ int Eval::avaliar(){
         else if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_da_dama){
             shield = peao_ala_da_dama[BRANCAS];
         }
-        mg_score[BRANCAS] += shield;
-        eg_score[BRANCAS] += shield;
+        score[BRANCAS] += make_score(shield, shield);
     }
 
     if (Bitboard::bit_pieces[BRANCAS][D] == 0){
         const int rei_eg = reis_score_finais[PRETAS][Bitboard::bitscan(Bitboard::bit_pieces[PRETAS][R])];
-        mg_score[PRETAS] += rei_eg;
-        eg_score[PRETAS] += rei_eg;
+        score[PRETAS] += make_score(rei_eg, rei_eg);
     }
     else {
         int shield = 0;
@@ -209,12 +226,13 @@ int Eval::avaliar(){
         else if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_da_dama){
             shield = peao_ala_da_dama[PRETAS];
         }
-        mg_score[PRETAS] += shield;
-        eg_score[PRETAS] += shield;
+        score[PRETAS] += make_score(shield, shield);
     }
 
+    // Side-to-move difference, then unpack and interpolate.
+    const Score diff = score[Game::lado] - score[Game::xlado];
+    const int mg_diff = mg_score(diff);
+    const int eg_diff = eg_score(diff);
     const int phase = fase();
-    const int mg_diff = mg_score[Game::lado] - mg_score[Game::xlado];
-    const int eg_diff = eg_score[Game::lado] - eg_score[Game::xlado];
     return (mg_diff * phase + eg_diff * (PHASE_MAX - phase)) / PHASE_MAX;
 }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -5,7 +5,8 @@
 #include "game.h"
 
 
-int Eval::score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+int Eval::score_casas_mg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+int Eval::score_casas_eg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
 int Eval::reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
 int Eval::passados[LADOS][CASAS_DO_TABULEIRO];
 
@@ -16,26 +17,40 @@ int peao_ala_da_dama[LADOS],peao_ala_do_rei[LADOS];
 
 void Eval::init_eval_tables(){
     for (int x = 0; x < CASAS_DO_TABULEIRO; x++){
-        score_casas[BRANCAS][P][x] = Values::peao_score[x] + VALOR_PEAO;
-        score_casas[BRANCAS][C][x] = Values::cavalo_score[x] + VALOR_CAVALO;
-        score_casas[BRANCAS][B][x] = Values::bispo_score[x] + VALOR_BISPO;
-        score_casas[BRANCAS][T][x] = Values::torre_score[x] + VALOR_TORRE;
-        score_casas[BRANCAS][D][x] = Values::dama_score[x] + VALOR_DAMA;
-        score_casas[BRANCAS][R][x] = Values::rei_score[x];
+        score_casas_mg[BRANCAS][P][x] = Values::peao_score[x] + VALOR_PEAO;
+        score_casas_mg[BRANCAS][C][x] = Values::cavalo_score[x] + VALOR_CAVALO;
+        score_casas_mg[BRANCAS][B][x] = Values::bispo_score[x] + VALOR_BISPO;
+        score_casas_mg[BRANCAS][T][x] = Values::torre_score[x] + VALOR_TORRE;
+        score_casas_mg[BRANCAS][D][x] = Values::dama_score[x] + VALOR_DAMA;
+        score_casas_mg[BRANCAS][R][x] = Values::rei_score[x];
 
-        score_casas[PRETAS][P][x] = Values::peao_score[Consts::flip[x]] + VALOR_PEAO;
-        score_casas[PRETAS][C][x] = Values::cavalo_score[Consts::flip[x]] + VALOR_CAVALO;
-        score_casas[PRETAS][B][x] = Values::bispo_score[Consts::flip[x]] + VALOR_BISPO;
-        score_casas[PRETAS][T][x] = Values::torre_score[Consts::flip[x]] + VALOR_TORRE;
-        score_casas[PRETAS][D][x] = Values::dama_score[Consts::flip[x]] + VALOR_DAMA;
-        score_casas[PRETAS][R][x] = Values::rei_score[Consts::flip[x]];
-        
-        reis_score_finais[BRANCAS][x] = Values::rei_finais_score[x] - score_casas[BRANCAS][R][x];
-        reis_score_finais[PRETAS][x] = Values::rei_finais_score[x] - score_casas[PRETAS][R][x];
+        score_casas_mg[PRETAS][P][x] = Values::peao_score[Consts::flip[x]] + VALOR_PEAO;
+        score_casas_mg[PRETAS][C][x] = Values::cavalo_score[Consts::flip[x]] + VALOR_CAVALO;
+        score_casas_mg[PRETAS][B][x] = Values::bispo_score[Consts::flip[x]] + VALOR_BISPO;
+        score_casas_mg[PRETAS][T][x] = Values::torre_score[Consts::flip[x]] + VALOR_TORRE;
+        score_casas_mg[PRETAS][D][x] = Values::dama_score[Consts::flip[x]] + VALOR_DAMA;
+        score_casas_mg[PRETAS][R][x] = Values::rei_score[Consts::flip[x]];
+
+        for (int p = 0; p < TIPOS_DE_PIECES; p++){
+            score_casas_eg[BRANCAS][p][x] = score_casas_mg[BRANCAS][p][x];
+            score_casas_eg[PRETAS][p][x]  = score_casas_mg[PRETAS][p][x];
+        }
+
+        reis_score_finais[BRANCAS][x] = Values::rei_finais_score[x] - score_casas_mg[BRANCAS][R][x];
+        reis_score_finais[PRETAS][x] = Values::rei_finais_score[x] - score_casas_mg[PRETAS][R][x];
 
         passados[BRANCAS][x] = Values::peao_passado_score[Consts::flip[x]];
         passados[PRETAS][x] = Values::peao_passado_score[x];
     }
+}
+
+int Eval::fase(){
+    int phase = PHASE_CAVALO * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][C] | Bitboard::bit_pieces[PRETAS][C])
+              + PHASE_BISPO  * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][B] | Bitboard::bit_pieces[PRETAS][B])
+              + PHASE_TORRE  * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][T] | Bitboard::bit_pieces[PRETAS][T])
+              + PHASE_DAMA   * Bitboard::popcount(Bitboard::bit_pieces[BRANCAS][D] | Bitboard::bit_pieces[PRETAS][D]);
+    if (phase > PHASE_MAX) phase = PHASE_MAX;
+    return phase;
 }
 
 void Eval::atualizar_materiais(){
@@ -99,7 +114,8 @@ int avaliar_torre(const int l, const int casa){
 }
 
 int Eval::avaliar(){
-    int score[LADOS] = {0, 0};
+    int mg_score[LADOS] = {0, 0};
+    int eg_score[LADOS] = {0, 0};
 
     peao_ala_da_dama[BRANCAS] = 0;
     peao_ala_do_rei[BRANCAS] = 0;
@@ -110,14 +126,17 @@ int Eval::avaliar(){
     int casa;
 
     for (int l = 0; l < LADOS; l++){
-        
+
         t1 = Bitboard::bit_pieces[l][P];
         while (t1){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            score[l] += score_casas[l][P][casa];
-            score[l] += avaliar_peao(l, casa);
+            mg_score[l] += score_casas_mg[l][P][casa];
+            eg_score[l] += score_casas_eg[l][P][casa];
+            const int peao_b = avaliar_peao(l, casa);
+            mg_score[l] += peao_b;
+            eg_score[l] += peao_b;
         }
 
         t1 = Bitboard::bit_pieces[l][C];
@@ -125,7 +144,8 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            score[l] += score_casas[l][C][casa];
+            mg_score[l] += score_casas_mg[l][C][casa];
+            eg_score[l] += score_casas_eg[l][C][casa];
         }
 
         t1 = Bitboard::bit_pieces[l][B];
@@ -133,7 +153,8 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            score[l] += score_casas[l][B][casa];
+            mg_score[l] += score_casas_mg[l][B][casa];
+            eg_score[l] += score_casas_eg[l][B][casa];
         }
 
         t1 = Bitboard::bit_pieces[l][T];
@@ -141,8 +162,11 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            score[l] += score_casas[l][T][casa];
-            score[l] += avaliar_torre(l, casa);
+            mg_score[l] += score_casas_mg[l][T][casa];
+            eg_score[l] += score_casas_eg[l][T][casa];
+            const int torre_b = avaliar_torre(l, casa);
+            mg_score[l] += torre_b;
+            eg_score[l] += torre_b;
         }
 
         t1 = Bitboard::bit_pieces[l][D];
@@ -150,33 +174,47 @@ int Eval::avaliar(){
             casa = Bitboard::bitscan(t1);
             t1 &= Bitboard::not_mask[casa];
 
-            score[l] += score_casas[l][D][casa];
+            mg_score[l] += score_casas_mg[l][D][casa];
+            eg_score[l] += score_casas_eg[l][D][casa];
         }
     }
 
     if (Bitboard::bit_pieces[PRETAS][D] == 0){
-        score[BRANCAS] += reis_score_finais[BRANCAS][Bitboard::bitscan(Bitboard::bit_pieces[BRANCAS][R])];
+        const int rei_eg = reis_score_finais[BRANCAS][Bitboard::bitscan(Bitboard::bit_pieces[BRANCAS][R])];
+        mg_score[BRANCAS] += rei_eg;
+        eg_score[BRANCAS] += rei_eg;
     }
     else{
+        int shield = 0;
         if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_do_rei){
-            score[BRANCAS] += peao_ala_do_rei[BRANCAS];
+            shield = peao_ala_do_rei[BRANCAS];
         }
         else if (Bitboard::bit_pieces[BRANCAS][R] & Bitboard::mask_ala_da_dama){
-            score[BRANCAS] += peao_ala_da_dama[BRANCAS];
+            shield = peao_ala_da_dama[BRANCAS];
         }
+        mg_score[BRANCAS] += shield;
+        eg_score[BRANCAS] += shield;
     }
 
     if (Bitboard::bit_pieces[BRANCAS][D] == 0){
-        score[PRETAS] += reis_score_finais[PRETAS][Bitboard::bitscan(Bitboard::bit_pieces[PRETAS][R])];
+        const int rei_eg = reis_score_finais[PRETAS][Bitboard::bitscan(Bitboard::bit_pieces[PRETAS][R])];
+        mg_score[PRETAS] += rei_eg;
+        eg_score[PRETAS] += rei_eg;
     }
     else {
+        int shield = 0;
         if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_do_rei){
-            score[PRETAS] += peao_ala_do_rei[PRETAS];
+            shield = peao_ala_do_rei[PRETAS];
         }
         else if (Bitboard::bit_pieces[PRETAS][R] & Bitboard::mask_ala_da_dama){
-            score[PRETAS] += peao_ala_da_dama[PRETAS];
+            shield = peao_ala_da_dama[PRETAS];
         }
+        mg_score[PRETAS] += shield;
+        eg_score[PRETAS] += shield;
     }
 
-    return score[Game::lado] - score[Game::xlado];
+    const int phase = fase();
+    const int mg_diff = mg_score[Game::lado] - mg_score[Game::xlado];
+    const int eg_diff = eg_score[Game::lado] - eg_score[Game::xlado];
+    return (mg_diff * phase + eg_diff * (PHASE_MAX - phase)) / PHASE_MAX;
 }

--- a/src/eval.h
+++ b/src/eval.h
@@ -1,20 +1,64 @@
 #ifndef EVAL
 #define EVAL
 
+#include <cstdint>
+
 #include "consts.h"
 
 namespace Eval{
-    extern int score_casas_mg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
-    extern int score_casas_eg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+    // Packed midgame/endgame score (Stockfish-style). eg lives in the high
+    // 16 bits, mg in the low 16. Construction uses + (not |) and the eg
+    // extractor adds 0x8000 to round-correct the carry that mg's negative
+    // sign-extension introduces into the eg half during +. With this
+    // encoding, plain int32 addition of two Scores correctly sums both mg
+    // and eg as if computed independently (verified algebraically: the
+    // borrow from negative mg cancels symmetrically when both operands
+    // share the same encoding). Per-half range stays signed int16.
+    typedef int32_t Score;
+
+    inline Score make_score(int mg, int eg){
+        return (Score)(((uint32_t)eg << 16) + (uint32_t)mg);
+    }
+    // mg extraction is a clean low-16 mask + sign extension.
+    inline int mg_score(Score s){
+        return (int16_t)((uint32_t)s & 0xFFFF);
+    }
+    // eg extraction adds 0x8000 first so the high-16 read rounds up by one
+    // when mg has its sign bit set (i.e. mg < 0), undoing the borrow that
+    // the construction `+` left in the high half.
+    inline int eg_score(Score s){
+        return (int16_t)(((uint32_t)s + 0x8000) >> 16);
+    }
+
+    // Single packed PST + material table replacing the previous mg/eg pair.
+    // Memory footprint stays the same (one int32 per slot vs two int32s), so
+    // cache behavior is comparable, but every per-piece accumulation in
+    // `avaliar` becomes one load + one add instead of two of each.
+    extern Score score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
     extern int reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
     extern int passados[LADOS][CASAS_DO_TABULEIRO];
 
     extern int peao_mat[2];
     extern int piece_mat[2];
 
+    // Incremental phase counter: maintained by Update::adicionar_piece /
+    // Update::remover_piece (one += / -= per call) instead of recomputed
+    // on every Eval::avaliar. Reset to 0 at each board-init path
+    // (Bitboard::init_board, Game::nova_posicao, Update::setar_posicao);
+    // those routines already loop through adicionar_piece per square, so
+    // the counter naturally accumulates the full position's phase weight.
+    // Like peao_mat / piece_mat / peao_ala_*, this is currently a global —
+    // when Lazy SMP arrives (§15 item 19) all of them migrate to per-thread
+    // state together.
+    extern int fase_valor;
+    extern const int phase_weights[6];
+
     void init_eval_tables();
     void atualizar_materiais();
 
+    // Cheap accessor: clamps fase_valor to [0, PHASE_MAX]. Promotion to a
+    // 9th queen could push the raw counter past PHASE_MAX, so the clamp
+    // keeps the interpolation in its valid range.
     int fase();
 
     int avaliar();

--- a/src/eval.h
+++ b/src/eval.h
@@ -35,7 +35,6 @@ namespace Eval{
     // cache behavior is comparable, but every per-piece accumulation in
     // `avaliar` becomes one load + one add instead of two of each.
     extern Score score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
-    extern int reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
     extern int passados[LADOS][CASAS_DO_TABULEIRO];
 
     extern int peao_mat[2];

--- a/src/eval.h
+++ b/src/eval.h
@@ -4,7 +4,8 @@
 #include "consts.h"
 
 namespace Eval{
-    extern int score_casas[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+    extern int score_casas_mg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
+    extern int score_casas_eg[LADOS][TIPOS_DE_PIECES][CASAS_DO_TABULEIRO];
     extern int reis_score_finais[LADOS][CASAS_DO_TABULEIRO];
     extern int passados[LADOS][CASAS_DO_TABULEIRO];
 
@@ -13,6 +14,8 @@ namespace Eval{
 
     void init_eval_tables();
     void atualizar_materiais();
+
+    int fase();
 
     int avaliar();
 };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -54,6 +54,10 @@ void Game::nova_posicao(){
     Eval::piece_mat[BRANCAS] = Eval::peao_mat[BRANCAS] = 0;
     Eval::piece_mat[PRETAS] = Eval::peao_mat[PRETAS] = 0;
 
+    // Reset the incremental phase counter so the adicionar_piece loop
+    // below rebuilds it from scratch (just like the material counters above).
+    Eval::fase_valor = 0;
+
     for (int casa = 0; casa < CASAS_DO_TABULEIRO; casa++){
         if (Bitboard::tabuleiro[casa] < VAZIO){
             if (Bitboard::bit_lados[BRANCAS] & Bitboard::mask[casa]){

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -13,6 +13,7 @@
 #include "hash.h"
 #include "game.h"
 #include "attacks.h"
+#include "eval.h"
 
 int casa_reversa[LADOS] = {-8,8};
 
@@ -42,6 +43,8 @@ void Update::remover_piece(const int l, const int p, const int casa){
     Bitboard::bit_lados[l] &= Bitboard::not_mask[casa];
     Bitboard::bit_pieces[l][p] &= Bitboard::not_mask[casa];
     Bitboard::bit_total = Bitboard::bit_lados[BRANCAS] | Bitboard::bit_lados[PRETAS];
+
+    Eval::fase_valor -= Eval::phase_weights[p];
 }
 
 void Update::desfaz_lance(){
@@ -218,6 +221,8 @@ void Update::adicionar_piece(const int l, const int piece, const int casa){
     Bitboard::bit_lados[l] |= Bitboard::mask[casa];
     Bitboard::bit_pieces[l][piece] |= Bitboard::mask[casa];
     Bitboard::bit_total = Bitboard::bit_lados[BRANCAS] | Bitboard::bit_lados[PRETAS];
+
+    Eval::fase_valor += Eval::phase_weights[piece];
 }
 
 void Update::desfaz_captura(){
@@ -511,6 +516,7 @@ void Update::setar_posicao(char posicao[80], char lado_a_jogar[1], char roques[4
     memset(Bitboard::bit_pieces, 0, sizeof(Bitboard::bit_pieces));
     memset(Bitboard::bit_lados, 0, sizeof(Bitboard::bit_lados));
     Bitboard::bit_total = 0;
+    Eval::fase_valor = 0;
 
     for (int casa = 0; casa < CASAS_DO_TABULEIRO; casa++){
         Bitboard::tabuleiro[casa] = VAZIO;

--- a/src/values.h
+++ b/src/values.h
@@ -29,6 +29,14 @@ namespace Values{
 	#define COLUNA_SEMI_ABERTA_BONUS 11
 	#define COLUNA_ABERTA_BONUS 40
 
+	#define PHASE_PEAO    0
+	#define PHASE_CAVALO  1
+	#define PHASE_BISPO   1
+	#define PHASE_TORRE   2
+	#define PHASE_DAMA    4
+	#define PHASE_REI     0
+	#define PHASE_MAX    24
+
 
 	// REDUÇÕES E CONDIÇÕES
 	#define REDUCAO_IID /4


### PR DESCRIPTION
Adiciona estrutura de tapered eval.
PST de rei sendo mesclado de maneira sutil (tapered) ao invés de um branch abrupto

Ganhos:
```
Results of candidate vs baseline (10+0.1, 1t, 256MB, UHO_Lichess_4852_v1.epd):
Elo: 25.18 +/- 11.26, nElo: 29.92 +/- 13.32
LOS: 100.00 %, DrawRatio: 34.15 %, PairsRatio: 1.32
Games: 2612, Wins: 996, Losses: 807, Draws: 809, Points: 1400.5 (53.62 %)
Ptnml(0-2): [133, 238, 446, 285, 204], WL/DD Ratio: 2.12
LLR: 2.95 (100.1%) (-2.94, 2.94) [0.00, 5.00]
```